### PR TITLE
Do not check bus state in `loop()`

### DIFF
--- a/actuators/blind-shutter/rol-jal-bcu1/src/app_main.cpp
+++ b/actuators/blind-shutter/rol-jal-bcu1/src/app_main.cpp
@@ -49,8 +49,7 @@ void loop()
     checkPeriodicFuntions();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
@@ -69,8 +69,7 @@ void loop()
     checkPeriodicFuntions();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/actuators/dimmer/out8-dimmer-bim112/src/app_main.cpp
+++ b/actuators/dimmer/out8-dimmer-bim112/src/app_main.cpp
@@ -105,8 +105,7 @@ void loop()
     checkPeriodicFuntions();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
     if (timeout.started() && timeout.expired())
     {
     	timeout.start(1000);

--- a/actuators/led-controller/dim4-bim112/src/app_main.cpp
+++ b/actuators/led-controller/dim4-bim112/src/app_main.cpp
@@ -51,8 +51,7 @@ void loop()
     checkPeriodic();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/actuators/led-controller/led-4-channels-bim112/src/app_main.cpp
+++ b/actuators/led-controller/led-4-channels-bim112/src/app_main.cpp
@@ -68,8 +68,7 @@ void loop()
     checkPeriodicFuntions();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 void initApplication(void)

--- a/actuators/outputs/out-cs-bim112/src/app_main.cpp
+++ b/actuators/outputs/out-cs-bim112/src/app_main.cpp
@@ -378,8 +378,8 @@ void MainProcessingRoutine(bool AppValid)
  //============
  LedProcessing();
 
- //if (bus.idle()) // alle 10µs kommt ein INT, also ist das Sleep hier eher theoretischer Natur.
-   waitForInterrupt();
+ // alle 10µs kommt ein INT, also ist das Sleep hier eher theoretischer Natur.
+ waitForInterrupt();
 }
 
 /*

--- a/actuators/outputs/out8-bcu1/src/app_main.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_main.cpp
@@ -257,11 +257,8 @@ void loop(void)
     checkTimeouts();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-    {
-        waitForInterrupt();
-        printSerialBusVoltage(500);
-    }
+    waitForInterrupt();
+    printSerialBusVoltage(500);
 }
 
 /**

--- a/misc/MultiSensorAktor/src/app_main.cpp
+++ b/misc/MultiSensorAktor/src/app_main.cpp
@@ -156,10 +156,7 @@ void loop()
     while ((objNo = bcu.comObjects->nextUpdatedObject()) >= 0);
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-    {
-        waitForInterrupt();
-    }
+    waitForInterrupt();
 }
 
 /**

--- a/misc/Rauchmelder-bcu1/src/sd_app.cpp
+++ b/misc/Rauchmelder-bcu1/src/sd_app.cpp
@@ -98,8 +98,7 @@ void SmokeDetectorApp::loop()
     }
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 void SmokeDetectorApp::loopNoApp()

--- a/misc/weatherstation-bim112/src/app_main.cpp
+++ b/misc/weatherstation-bim112/src/app_main.cpp
@@ -72,8 +72,7 @@ void loop()
     checkPeriodicFuntions();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 void initApplication(void)

--- a/sensors/binary-inputs/RGBswitch_6-bcu1/src/app_main.cpp
+++ b/sensors/binary-inputs/RGBswitch_6-bcu1/src/app_main.cpp
@@ -153,8 +153,7 @@ void loop()
     handlePeriodic();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/binary-inputs/in16-bim112/src/app_main.cpp
+++ b/sensors/binary-inputs/in16-bim112/src/app_main.cpp
@@ -52,8 +52,7 @@ void loop()
     checkPeriodic();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/binary-inputs/in4-bcu2/src/app_main.cpp
+++ b/sensors/binary-inputs/in4-bcu2/src/app_main.cpp
@@ -88,8 +88,7 @@ void loop()
     }
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/binary-inputs/in8-bcu1/src/app_main.cpp
+++ b/sensors/binary-inputs/in8-bcu1/src/app_main.cpp
@@ -202,8 +202,7 @@ void loop()
     handlePeriodic();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/binary-inputs/rain-bim112/src/app_main.cpp
+++ b/sensors/binary-inputs/rain-bim112/src/app_main.cpp
@@ -250,7 +250,7 @@ void loop() {
         doPeriodics();
     }
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle()) waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/misc/4sense-bcu1/src/app_main.cpp
+++ b/sensors/misc/4sense-bcu1/src/app_main.cpp
@@ -17,7 +17,7 @@ void loop() {
         }
     }
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle()) waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/misc/4volt-bcu1/src/app_main.cpp
+++ b/sensors/misc/4volt-bcu1/src/app_main.cpp
@@ -9,7 +9,7 @@ void loop() {
         sc.doPeriodics();
     }
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle()) waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/misc/dustsensor-bcu1/src/app_main.cpp
+++ b/sensors/misc/dustsensor-bcu1/src/app_main.cpp
@@ -258,8 +258,7 @@ void loop()
 //    }
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/misc/lightsensor-bcu1/src/app_main.cpp
+++ b/sensors/misc/lightsensor-bcu1/src/app_main.cpp
@@ -7,7 +7,7 @@ void loop() {
     sc->readValues();
     sc->doPeriodics();
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle()) waitForInterrupt();
+    waitForInterrupt();
 }
 
 /**

--- a/sensors/misc/raincenter-bim112/src/app_main.cpp
+++ b/sensors/misc/raincenter-bim112/src/app_main.cpp
@@ -40,8 +40,7 @@ void loop()
     checkPeriodic();
 
     // Sleep up to 1 millisecond if there is nothing to do
-    if (bcu.bus->idle())
-        waitForInterrupt();
+    waitForInterrupt();
 }
 
 void loop_noapp()


### PR DESCRIPTION
As sblib's `Bus` implementation uses interrupts for everything, there is no need to pump the loop if the bus is not idle, i.e. when it is currently sending, receiving, or waiting.