### PR TITLE
Fix/out8 logic

### DIFF
--- a/actuators/outputs/out8-bcu1/.cproject
+++ b/actuators/outputs/out8-bcu1/.cproject
@@ -9,7 +9,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -155,7 +155,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -301,7 +301,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -446,7 +446,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -592,7 +592,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -737,7 +737,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -878,7 +878,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -1023,7 +1023,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -1168,7 +1168,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -1314,7 +1314,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -1459,7 +1459,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -1604,7 +1604,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -1749,7 +1749,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -1894,7 +1894,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -2039,7 +2039,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -2184,7 +2184,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -2329,7 +2329,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -2474,7 +2474,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -2619,7 +2619,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -2764,7 +2764,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -2909,7 +2909,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -3054,7 +3054,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value="BI_STABLE"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -3199,7 +3199,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -3344,7 +3344,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -3489,7 +3489,7 @@
 					<stringMacro name="relay_type" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.11"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="5.12"/>
 				</macros>
 				<externalSettings/>
 				<extensions>

--- a/actuators/outputs/out8-bcu1/src/app_main.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_main.cpp
@@ -40,7 +40,7 @@
     AppUsrCallback usrCallback; ///\todo two callbacks? Optimize with busfail integration into the sblib.
 #endif
 
-APP_VERSION("O08.10  ", "5", "11");
+APP_VERSION("O08.10  ", "5", "12");
 
 /**
  * Simple IO test

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -240,9 +240,10 @@ void handleBooleanLogic(const SpecialFunctionConfig cfg, int objno, unsigned int
 
 void handleBlockingLogic(const SpecialFunctionConfig cfg)
 {
-    bool startBlocking;         // true if a blocking is started
-    bool endBlocking;           // true if a blocking was ended
-    blockType blockTyp;         // holds the type of blocking
+    uint8_t affectedOutput = cfg.specialFuncOutput;
+    bool startBlocking; // true if a blocking is started
+    bool endBlocking;   // true if a blocking was ended
+    blockType blockTyp; // holds the blocking type
 
     startBlocking = (bcu.comObjects->objectRead(COMOBJ_SPECIAL1 + cfg.specialFuncNumber) ^ (cfg.lockPolarity)) & 0x01;
     endBlocking = false;
@@ -256,9 +257,9 @@ void handleBlockingLogic(const SpecialFunctionConfig cfg)
         // action at end of blocking
         blockTyp = cfg.blockTypeEnd;
         // end blocking, we have to unblock relays
-        if (relays.blocked(cfg.specialFuncOutput))
+        if (relays.blocked(affectedOutput))
         {
-            relays.clearBlocked(cfg.specialFuncOutput);
+            relays.clearBlocked(affectedOutput);
             endBlocking = true;
         }
     }
@@ -271,10 +272,10 @@ void handleBlockingLogic(const SpecialFunctionConfig cfg)
         case blNoAction : // no action
             break;
         case blDisable : // disable the output
-            relays.updateChannel(cfg.specialFuncOutput, false);
+            relays.updateChannel(affectedOutput, false);
             break;
         case blEnable : // enable the output
-            relays.updateChannel(cfg.specialFuncOutput, true);
+            relays.updateChannel(affectedOutput, true);
             break;
         default:
             break;
@@ -283,8 +284,9 @@ void handleBlockingLogic(const SpecialFunctionConfig cfg)
 
     // finally set relays blocked in case of blocking start
     if (startBlocking)
-        relays.setBlocked(cfg.specialFuncOutput);
-
+    {
+        relays.setBlocked(affectedOutput);
+    }
 }
 
 void handleForcedPositioning(const SpecialFunctionConfig cfg, const int16_t objno)

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -402,7 +402,7 @@ static unsigned int _handle_timed_functions(const int objno, const unsigned int 
 
 void objectUpdated(int objno)
 {
-    unsigned int value = bcu.comObjects->objectRead(objno); // get value of object (0=off, 1=on)
+    unsigned int value = bcu.comObjects->objectRead(objno); // 0=off, 1=on or 2 bits for forced positioning (Zwangsstellung)
 
     // check if we have a delayed action for this object, only Outputs
     if (objno < COMOBJ_SPECIAL1) // logic objects must be checked here to
@@ -417,7 +417,7 @@ void objectUpdated(int objno)
     }
 
     // handle the logic functions for this channel
-    _handle_logic_function (objno, value);  //FIXME logic will override on/off delays
+    _handle_logic_function (objno, value);  ///\todo boolean logic will override on/off delays
 
     if (relays.pendingChanges())
         _switchObjects(BETWEEN_CHANNEL_DELAY_MS);

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -47,7 +47,7 @@ static ChannelTimeOutTimer channel_timeout[NO_OF_CHANNELS];
 // internal functions
 static void          _switchObjects(unsigned int delayms = 0);
 static void          _sendFeedbackObjects(bool forceSendFeedback = false);
-static void          _handle_logic_function(int objno, unsigned int value);
+static void          _handle_logic_function(int16_t objno, uint8_t value);
 static unsigned int  _handle_timed_functions(const int objno, const unsigned int value);
 
 
@@ -309,7 +309,7 @@ void handleForcedPositioning(const SpecialFunctionConfig cfg, const int16_t objn
     }
 }
 
-static void _handle_logic_function(int objno, unsigned int value)
+static void _handle_logic_function(int16_t objno, uint8_t value)
 {
     SpecialFunctionConfig config = getSpecialFunctionConfig(objno);
 

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -455,7 +455,7 @@ void checkTimeouts(void)
         {
             unsigned int newValue = (onTimedout == true);
             relays.updateChannel(objno, newValue);
-            bcu.comObjects->objectWrite(objno, newValue);
+            bcu.comObjects->objectWrite(COMOBJ_FEEDBACK1 + objno, newValue);
             _handle_timed_functions(objno, newValue);
             _handle_logic_function(objno, newValue);
         }

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -309,25 +309,27 @@ void handleForcedPositioning(const SpecialFunctionConfig cfg, const int16_t objn
 
 static void _handle_logic_function(int objno, unsigned int value)
 {
-    // FIXME debug the logic handling! untested right now
     SpecialFunctionConfig sfcfg = getSpecialFunctionConfig(objno);
 
+    ///\todo Logic handling is mostly untested
     switch (sfcfg.Mode)
     {
-    case sftUnknown :
-         break; // sftUnknown
+        case sftLogic: // OR/AND/AND with recirculation
+            handleBooleanLogic(sfcfg, objno, value);
+            break;
 
-    case sftLogic: // OR/AND/AND with recirculation
-        handleBooleanLogic(sfcfg, objno, value);
-        break;
+        case sftBlocking:
+            handleBlockingLogic(sfcfg);
+            break;
 
-    case sftBlocking:
-        handleBlockingLogic(sfcfg);
-        break;
+        case sftForcedPositioning: // Zwangsstellung
+                handleForcedPositioning(sfcfg, objno, value);
+                break;
+        case sftUnknown:
+            break;
 
-    case sftForcedPositioning: // Zwangsstellung
-        handleForcedPositioning(sfcfg, objno, value);
-        break;
+        default:
+            break;
     }
 }
 

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -577,15 +577,17 @@ void initApplication(int lastRelayState)
             newRelaystate |= 1 << i;
     }
 
-    // set all logic objects to false
-    for (i=COMOBJ_SPECIAL1; i <= COMOBJ_SPECIAL4; i++)
-        bcu.comObjects->objectSetValue(i, (unsigned int) 0);
-
     // set all output objects according to configured initial output state
     for (i=COMOBJ_INPUT1; i < (sizeof(initialOutputState)/sizeof(initialOutputState[0])); i++)
     {
         unsigned int value = (initialOutputState[i] == Outputs::CLOSED);
         bcu.comObjects->objectSetValue(i, value);
+    }
+
+    for (i=COMOBJ_SPECIAL1; i <= COMOBJ_SPECIAL4; i++)
+    {
+        bcu.comObjects->objectSetValue(i, (unsigned int) 0); // set all logic objects to false
+        bcu.comObjects->requestObjectRead(i); // read values of logic objects (8-11) from the KNX bus
     }
 
     // according to the jung manual, outputs are switched on/off on startup, ignoring timed functions or logics

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -185,12 +185,10 @@ static TimerConfig getTimerCfg(const int objno)
     return timercfg;
 }
 
-void handleBooleanLogic(const SpecialFunctionConfig cfg, int objno, unsigned int value)
+void handleBooleanLogic(const SpecialFunctionConfig cfg)
 {
     unsigned int logicState;    // state of logic function
-
-    if ((objno >= COMOBJ_SPECIAL1) && (objno <= COMOBJ_SPECIAL4))// need the value of the actual input 0-7
-        value = bcu.comObjects->objectRead(cfg.specialFuncOutput);
+    bool value = bcu.comObjects->objectRead(cfg.specialFuncOutput);
 
     // get the logic state for the special function object
     logicState = bcu.comObjects->objectRead(COMOBJ_SPECIAL1 + cfg.specialFuncNumber);
@@ -317,7 +315,7 @@ static void _handle_logic_function(int16_t objno, uint8_t value)
     switch (config.Mode)
     {
         case sftLogic: // OR/AND/AND with recirculation
-            handleBooleanLogic(config, objno, value);
+            handleBooleanLogic(config);
             break;
 
         case sftBlocking:

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -287,13 +287,13 @@ void handleBlockingLogic(const SpecialFunctionConfig cfg)
 
 }
 
-void handleForcedPositioning(const SpecialFunctionConfig cfg, const int16_t objno, unsigned int value)
+void handleForcedPositioning(const SpecialFunctionConfig cfg, const int16_t objno)
 {
-    // 0x00 no priority, off
-    // 0x01 no priority, on
-    // 0x02 priority, off
-    // 0x03 priority, on
-    value = bcu.comObjects->objectRead (COMOBJ_SPECIAL1 + cfg.specialFuncNumber);
+    // 0b00 no priority, off
+    // 0b01 no priority, on
+    // 0b10    priority, off
+    // 0b11    priority, on
+    uint8_t value = bcu.comObjects->objectRead (COMOBJ_SPECIAL1 + cfg.specialFuncNumber);
     if (value & 0b10)
     {   // priority is active for this channel
         // set the value of the special com object as output state
@@ -309,22 +309,23 @@ void handleForcedPositioning(const SpecialFunctionConfig cfg, const int16_t objn
 
 static void _handle_logic_function(int objno, unsigned int value)
 {
-    SpecialFunctionConfig sfcfg = getSpecialFunctionConfig(objno);
+    SpecialFunctionConfig config = getSpecialFunctionConfig(objno);
 
     ///\todo Logic handling is mostly untested
-    switch (sfcfg.Mode)
+    switch (config.Mode)
     {
         case sftLogic: // OR/AND/AND with recirculation
-            handleBooleanLogic(sfcfg, objno, value);
+            handleBooleanLogic(config, objno, value);
             break;
 
         case sftBlocking:
-            handleBlockingLogic(sfcfg);
+            handleBlockingLogic(config);
             break;
 
         case sftForcedPositioning: // Zwangsstellung
-                handleForcedPositioning(sfcfg, objno, value);
+                handleForcedPositioning(config, objno);
                 break;
+
         case sftUnknown:
             break;
 

--- a/actuators/outputs/out8-bcu1/src/app_out8.cpp
+++ b/actuators/outputs/out8-bcu1/src/app_out8.cpp
@@ -302,7 +302,7 @@ void handleForcedPositioning(const SpecialFunctionConfig cfg, const int16_t objn
     else
     {   // priority was just deactivated
         // restore the output based on the object state
-        if ((objno >= COMOBJ_SPECIAL1) && ((objno >= COMOBJ_SPECIAL4)))
+        if ((objno >= COMOBJ_SPECIAL1) && ((objno <= COMOBJ_SPECIAL4)))
             relays.updateChannel(cfg.specialFuncOutput, bcu.comObjects->objectRead (cfg.specialFuncOutput));
     }
 }


### PR DESCRIPTION
This PR fixes some out8 logic bugs

- `OR/AND` was not working correct if only the state of the logic object (8-11) changed
- special function range check in forced positioning 
- 