### PR TITLE
[RM] Set ARM communication gpios to a safe state on restart

### DIFF
--- a/misc/Rauchmelder-bcu1/.cproject
+++ b/misc/Rauchmelder-bcu1/.cproject
@@ -4,7 +4,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.debug.29419348">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.29419348" moduleId="org.eclipse.cdt.core.settings" name="Debug">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="3.00"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="3.10"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -151,7 +151,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.189047520">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.189047520" moduleId="org.eclipse.cdt.core.settings" name="Release">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="3.00"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="3.10"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -276,7 +276,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.debug.29419348.1178034494">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.29419348.1178034494" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x7000 Debug">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="3.00"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="3.10"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -423,7 +423,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.189047520.1296647534">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.189047520.1296647534" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="3.00"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="3.10"/>
 				</macros>
 				<externalSettings/>
 				<extensions>

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_A.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_A.md
@@ -5,7 +5,8 @@ Unmounted modules do not interfere with operating modules on the bus.
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| A | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| A | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| A | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 * Use a single module, unmounted (not connected to smoke alarm device)

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_1.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_1.md
@@ -30,4 +30,4 @@ Startup sequence and timing correct.
 
 **Verify:**
 * Sends the `Error code` and `Smoke detector malfunction` group objects (communication objects 12 and 14) with values `0` and `false` immediately
-* Sends all informational group objects with sensible values within the first minute of operation
+* Sends all informational group objects (except communication object 5 `Test alarm status`) with sensible values within the first minute of operation

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_1.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_1.md
@@ -5,8 +5,9 @@ Startup sequence and timing correct.
 
 | Test case | Device | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | --- | :---: |
-| B.1 | Dual VdS | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| | Dual Q | @Doumanix | 2023-12-23 | a6e41e38be984ce5c6b8985c9ec173a85ef35d48 | :ok: |
+| B.1 | Dual VdS | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|     | Dual Q   | @Doumanix  | 2023-12-23 | a6e41e38be984ce5c6b8985c9ec173a85ef35d48 | :ok: |
+|     | Dual Q   | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 * Setup per [Tests A](tests_A.md)

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_2.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_2.md
@@ -5,9 +5,12 @@ Parameters regarding periodic sending of `Alarm Status` `0` respected, i.e. when
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| B.2.a | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.2.b | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.2.c | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| B.2.a | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.2.b | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.2.c | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 Setup per finished [Tests B.1](tests_B_1.md), i.e. fully configured module mounted in smoke alarm device, and Group Monitor running.

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_3.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_3.md
@@ -5,26 +5,46 @@ Parameters regarding periodic sending of Status Informations respected.
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| B.3.a | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.b | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.c | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.d | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.e | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.f | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.g | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.h | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.i | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.j | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.k | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.l | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.m | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.n | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.o | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.p | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.q | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.r | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.s | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.3.t | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| B.3.a | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.b | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.c | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.d | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.e | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.f | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.g | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.h | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.i | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.j | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.k | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.l | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.m | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.n | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.o | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.p | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.q | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.r | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.s | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.3.t | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 Setup per finished [Tests B.1](tests_B_1.md), i.e. fully configured module mounted in smoke alarm device, and Group Monitor running.

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_4.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_4.md
@@ -5,10 +5,14 @@ Positive and negative temperatures and temperature offsets work.
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| B.4.a | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.4.b | @dallmair | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.4.c | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.4.d | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| B.4.a | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.4.b | @dallmair  | 2023-12-20 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.4.c | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.4.d | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-20 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 Setup per finished [Tests B.1](tests_B_1.md), i.e. fully configured module mounted in smoke alarm device, and Group Monitor running.

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_5.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_5.md
@@ -5,11 +5,16 @@ Parameters regarding periodical sending of Test Alarm respected.
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| B.5.a | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.5.b | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.5.c | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.5.d | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.5.e | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| B.5.a | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.5.b | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.5.c | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.5.d | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.5.e | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 Setup per finished [Tests B.1](tests_B_1.md), i.e. fully configured module mounted in smoke alarm device, and Group Monitor running.

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_6.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_6.md
@@ -5,12 +5,17 @@ Parameters regarding periodic sending of Alarm respected.
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| B.6.a | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.6.b | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.6.c | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.6.d | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| B.6.e | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| | @dallmair | 2023-12-29 | a6e41e38be984ce5c6b8985c9ec173a85ef35d48 | :ok: |
+| B.6.a | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.6.b | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.6.c | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.6.d | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.6.e | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @dallmair  | 2023-12-29 | a6e41e38be984ce5c6b8985c9ec173a85ef35d48 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 Setup per finished [Tests B.1](tests_B_1.md), i.e. fully configured module mounted in smoke alarm device, and Group Monitor running.

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_7.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_7.md
@@ -26,6 +26,7 @@ Setup per finished [Tests B.1](tests_B_1.md), i.e. fully configured module mount
   - Interval [sec]: **5**
   - Send alarm delayed: **Yes**
   - Delay [sec]: **10**
+  - Add `Delayed Alarm` (communication object 4) to a groupadress
 * Download the changes to the device
 * Trigger alarm with a hair dryer
 

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_7.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_7.md
@@ -5,9 +5,11 @@ Delayed sending of Alarm implemented correctly.
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| B.7.a | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :x: |
-| | @dallmair | 2023-12-22 | a6e41e38be984ce5c6b8985c9ec173a85ef35d48 | :ok: |
-| B.7.b | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| B.7.a | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :x:  |
+|       | @dallmair  | 2023-12-22 | a6e41e38be984ce5c6b8985c9ec173a85ef35d48 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| B.7.b | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-21 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 Setup per finished [Tests B.1](tests_B_1.md), i.e. fully configured module mounted in smoke alarm device, and Group Monitor running.

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_C_1.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_C_1.md
@@ -5,8 +5,10 @@ Ensure correct handling of test alarms when smoke alarm devices are networked us
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| C.1.a | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| C.1.b | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| C.1.a | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-22 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| C.1.b | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-22 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 Use three smoke alarm devices in the following setup:

--- a/misc/Rauchmelder-bcu1/doc/tests/tests_C_2.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_C_2.md
@@ -5,8 +5,10 @@ Ensure correct handling of alarms when smoke alarm devices are networked using b
 
 | Test case | Tester | Date | Commit | Result |
 | --- | --- | --- | --- | :---: |
-| C.2.a | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
-| C.2.b | @dallmair | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+| C.2.a | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-22 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
+| C.2.b | @dallmair  | 2023-12-22 | a870a7c5b946b9443e7fba81ecee02e796dd77a9 | :ok: |
+|       | @Darthyson | 2024-11-22 | bd820b81e9b31380050ef2a95776e714b3d819a8 | :ok: |
 
 # Setup
 Hardware setup per [Tests C.1](tests_C_1.md).

--- a/misc/Rauchmelder-bcu1/inc/app_main.h
+++ b/misc/Rauchmelder-bcu1/inc/app_main.h
@@ -18,47 +18,16 @@
  *  published by the Free Software Foundation.
  */
 
-#include "app_main.h"
-#include "sd_app.h"
+#ifndef SMOKEDETECTOR_APP_MAIN_H_
+#define SMOKEDETECTOR_APP_MAIN_H_
 
-APP_VERSION("S_RM_H6 ", "3", "00") // Don't forget to also change the build-variable sw_version
+#include <sblib/usr_callback.h>
 
-SmokeDetectorApp *app = nullptr;
+class SmokeDetectorUsrCallback: public UsrCallback {
+public:
+    virtual void Notify(UsrCallbackType type);
+};
 
-/**
- * Application setup
- */
-BcuBase* setup()
-{
-    app = new SmokeDetectorApp();
-    return app->initialize();
-}
 
-/**
- * The application's main.
- */
-void loop()
-{
-    app->loop();
-}
-
-/**
- * The loop while no application is running.
- */
-void loop_noapp()
-{
-    app->loopNoApp();
-}
-
-void SmokeDetectorUsrCallback::Notify(UsrCallbackType type)
-{
-    switch (type)
-    {
-        case UsrCallbackType::reset : // Reset after an ETS-application download or simple @ref APCI_BASIC_RESTART_PDU
-            app->end();
-            break;
-
-        default :
-            break;
-    }
-}
+#endif /* SMOKEDETECTOR_APP_MAIN_H_ */
+/** @}*/

--- a/misc/Rauchmelder-bcu1/inc/sd_app.h
+++ b/misc/Rauchmelder-bcu1/inc/sd_app.h
@@ -43,6 +43,7 @@ public:
     void loop();
     void loopNoApp();
     void timer();
+    void onGPIOStateChanged();
     void end();
 
 private:

--- a/misc/Rauchmelder-bcu1/inc/sd_app.h
+++ b/misc/Rauchmelder-bcu1/inc/sd_app.h
@@ -43,6 +43,7 @@ public:
     void loop();
     void loopNoApp();
     void timer();
+    void end();
 
 private:
     uint8_t getRandomUInt8();

--- a/misc/Rauchmelder-bcu1/inc/sd_com.h
+++ b/misc/Rauchmelder-bcu1/inc/sd_com.h
@@ -74,6 +74,8 @@ public:
      */
     void initSerialCom();
 
+    void end();
+
     /**
      * Check whether one of the timeouts expired and act accordingly.
      */

--- a/misc/Rauchmelder-bcu1/inc/sd_device.h
+++ b/misc/Rauchmelder-bcu1/inc/sd_device.h
@@ -58,6 +58,7 @@ public:
     void loopCheckState();
     bool isReady() const;
     void end();
+    bool isCoverPlateAttached();
 
 private:
     void receivedMessage(uint8_t *bytes, uint8_t len);

--- a/misc/Rauchmelder-bcu1/inc/sd_device.h
+++ b/misc/Rauchmelder-bcu1/inc/sd_device.h
@@ -57,6 +57,7 @@ public:
     void loopReceiveBytes();
     void loopCheckState();
     bool isReady() const;
+    void end();
 
 private:
     void receivedMessage(uint8_t *bytes, uint8_t len);

--- a/misc/Rauchmelder-bcu1/src/app_main.cpp
+++ b/misc/Rauchmelder-bcu1/src/app_main.cpp
@@ -21,7 +21,7 @@
 #include "app_main.h"
 #include "sd_app.h"
 
-APP_VERSION("S_RM_H6 ", "3", "00") // Don't forget to also change the build-variable sw_version
+APP_VERSION("S_RM_H6 ", "3", "10") // Don't forget to also change the build-variable sw_version
 
 SmokeDetectorApp *app = nullptr;
 

--- a/misc/Rauchmelder-bcu1/src/sd_app.cpp
+++ b/misc/Rauchmelder-bcu1/src/sd_app.cpp
@@ -43,6 +43,7 @@ SmokeDetectorApp::SmokeDetectorApp()
       errorCode(new SmokeDetectorErrorCode(groupObjects)),
       device(new SmokeDetectorDevice(config, groupObjects, alarm, errorCode))
 {
+    end();
     isTimerInitialized = false;
     burstPreventionDelay.stop();
     startSendingInfoGroupObjects();
@@ -266,4 +267,9 @@ void SmokeDetectorApp::timer()
             }
         }
     }
+}
+
+void SmokeDetectorApp::end()
+{
+    device->end();
 }

--- a/misc/Rauchmelder-bcu1/src/sd_com.cpp
+++ b/misc/Rauchmelder-bcu1/src/sd_com.cpp
@@ -48,6 +48,13 @@ void SmokeDetectorCom::initSerialCom()
     serial.begin(9600);
 }
 
+void SmokeDetectorCom::end()
+{
+    serial.end();
+    pinMode(PIN_TX, INPUT | OPEN_DRAIN);
+    pinMode(PIN_RX, INPUT | OPEN_DRAIN);
+}
+
 /**
  * Check whether one of the timeouts expired and act accordingly.
  */

--- a/misc/Rauchmelder-bcu1/src/sd_device.cpp
+++ b/misc/Rauchmelder-bcu1/src/sd_device.cpp
@@ -35,6 +35,7 @@ SmokeDetectorDevice::SmokeDetectorDevice(const SmokeDetectorConfig *config, cons
       errorCode(errorCode),
       com(new SmokeDetectorCom(this))
 {
+    setSupplyVoltage(false);
     pinMode(DevicePowered.pinLed(), OUTPUT);
     digitalWrite(DevicePowered.pinLed(), false);
     pinMode(DevicePowered.pin(), INPUT | PULL_DOWN | HYSTERESIS); // smoke detector base plate state, pulldown configured, Pin is connected to 3.3V VCC of the RM
@@ -477,4 +478,12 @@ uint32_t SmokeDetectorDevice::readUInt32(const uint8_t *bytes)
 uint16_t SmokeDetectorDevice::readUInt16(const uint8_t *bytes)
 {
     return static_cast<uint16_t>((bytes[0] << 8) | bytes[1]);
+}
+
+void SmokeDetectorDevice::end()
+{
+    com->end();
+    setSupplyVoltage(false);
+    pinMode(CommunicationEnable.pin(), INPUT | OPEN_DRAIN);
+    state = DeviceState::initialized;
 }

--- a/misc/Rauchmelder-bcu1/src/sd_device.cpp
+++ b/misc/Rauchmelder-bcu1/src/sd_device.cpp
@@ -37,7 +37,7 @@ SmokeDetectorDevice::SmokeDetectorDevice(const SmokeDetectorConfig *config, cons
 {
     pinMode(DevicePowered.pinLed(), OUTPUT);
     digitalWrite(DevicePowered.pinLed(), false);
-    pinMode(DevicePowered.pin(), INPUT | PULL_DOWN); // smoke detector base plate state, pulldown configured, Pin is connected to 3.3V VCC of the RM
+    pinMode(DevicePowered.pin(), INPUT | PULL_DOWN | HYSTERESIS); // smoke detector base plate state, pulldown configured, Pin is connected to 3.3V VCC of the RM
 
     state = DeviceState::initialized;
     timeout.stop();


### PR DESCRIPTION
This PR addresses the issue that the ARM gpios in `INPUT/PULL_UP` state after a reset.
To reduce the risk of damage to the smoke detector MCU on a reset or restart:
- the ARM´s gpios `PIN_TX`, `PIN_RX` and `CommunicationEnable` are set to `INPUT/OPEN_DRAIN`
- the 12V power supply is switched off.