### PR TITLE
[rol-jal-bim112] Add 8-channel support, code refactoring and bug fixes

### DIFF
--- a/actuators/blind-shutter/rol-jal-bim112/.cproject
+++ b/actuators/blind-shutter/rol-jal-bim112/.cproject
@@ -1345,6 +1345,9 @@
 		<configuration configurationName="Flashstart 0x3000 Release 4ch ha">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
+		<configuration configurationName="Release 8ch bf">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
 		<configuration configurationName="Flashstart 0x3000 Release">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
@@ -1367,6 +1370,9 @@
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
 		<configuration configurationName="Flashstart 0x3000 Release bf ha">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Flashstart 0x3000 Release 8ch bf">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
 		<configuration configurationName="Flashstart 0x3000 Release 4ch bf ha">

--- a/actuators/blind-shutter/rol-jal-bim112/.cproject
+++ b/actuators/blind-shutter/rol-jal-bim112/.cproject
@@ -4,6 +4,9 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1896956369">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1896956369" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 4ch">
 				<macros>
+					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
+					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -133,6 +136,9 @@
 		<cconfiguration id="com.crt.advproject.config.exe.debug.462531644.949451388">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.462531644.949451388" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Debug 4ch">
 				<macros>
+					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
+					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -258,6 +264,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
+					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -393,6 +400,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
+					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -521,6 +529,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
+					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -654,7 +663,9 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 4ch ha">
 				<macros>
+					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
+					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -788,7 +799,9 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366" moduleId="org.eclipse.cdt.core.settings" name="Release 4ch ha">
 				<macros>
+					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
+					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>

--- a/actuators/blind-shutter/rol-jal-bim112/.cproject
+++ b/actuators/blind-shutter/rol-jal-bim112/.cproject
@@ -58,14 +58,7 @@
 								<option id="com.crt.advproject.gcc.hdrlib.479871198" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.1906086949" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.2101199042" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.189510947" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="NDEBUG"/>
-									<listOptionValue builtIn="false" value="CORE_M0"/>
-									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
-									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
-									<listOptionValue builtIn="false" value="__LPC11XX__"/>
-									<listOptionValue builtIn="false" value="__NEWLIB__"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.189510947" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
 								<option id="gnu.c.compiler.option.misc.other.1787083313" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1759788236" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.850666333" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
@@ -188,14 +181,7 @@
 								<option id="com.crt.advproject.gcc.hdrlib.19748687" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.264800783" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.1613793461" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.766097537" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="DEBUG"/>
-									<listOptionValue builtIn="false" value="CORE_M0"/>
-									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
-									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
-									<listOptionValue builtIn="false" value="__LPC11XX__"/>
-									<listOptionValue builtIn="false" value="__NEWLIB__"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.766097537" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
 								<option id="gnu.c.compiler.option.misc.other.1772127924" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.450793783" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1508961380" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="true" value="gnu.c.optimization.level.none" valueType="enumerated"/>
@@ -319,14 +305,7 @@
 								<option id="com.crt.advproject.gcc.hdrlib.1104869415" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.295478681" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.887910703" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1569765939" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="NDEBUG"/>
-									<listOptionValue builtIn="false" value="CORE_M0"/>
-									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
-									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
-									<listOptionValue builtIn="false" value="__LPC11XX__"/>
-									<listOptionValue builtIn="false" value="__NEWLIB__"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1569765939" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
 								<option id="gnu.c.compiler.option.misc.other.108724202" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1449864096" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.1108361002" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
@@ -451,14 +430,7 @@
 								<option id="com.crt.advproject.gcc.hdrlib.922923008" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.931902619" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.2114019256" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1719292716" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="DEBUG"/>
-									<listOptionValue builtIn="false" value="CORE_M0"/>
-									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
-									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
-									<listOptionValue builtIn="false" value="__LPC11XX__"/>
-									<listOptionValue builtIn="false" value="__NEWLIB__"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1719292716" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
 								<option id="gnu.c.compiler.option.misc.other.196339483" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1395647897" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.968211388" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="true" value="gnu.c.optimization.level.none" valueType="enumerated"/>
@@ -584,14 +556,7 @@
 								<option id="com.crt.advproject.gcc.hdrlib.2033175474" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.1364703739" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.115990314" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.897838209" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="NDEBUG"/>
-									<listOptionValue builtIn="false" value="CORE_M0"/>
-									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
-									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
-									<listOptionValue builtIn="false" value="__LPC11XX__"/>
-									<listOptionValue builtIn="false" value="__NEWLIB__"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.897838209" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
 								<option id="gnu.c.compiler.option.misc.other.345424755" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1629737013" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.1233089275" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
@@ -720,14 +685,7 @@
 								<option id="com.crt.advproject.gcc.hdrlib.509148988" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.1327797485" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.2055971673" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.268963728" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="NDEBUG"/>
-									<listOptionValue builtIn="false" value="CORE_M0"/>
-									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
-									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
-									<listOptionValue builtIn="false" value="__LPC11XX__"/>
-									<listOptionValue builtIn="false" value="__NEWLIB__"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.268963728" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
 								<option id="gnu.c.compiler.option.misc.other.402119941" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1949324127" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.328700878" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
@@ -856,14 +814,7 @@
 								<option id="com.crt.advproject.gcc.hdrlib.1026224388" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.1760880793" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.940796948" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.141099223" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="NDEBUG"/>
-									<listOptionValue builtIn="false" value="CORE_M0"/>
-									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
-									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
-									<listOptionValue builtIn="false" value="__LPC11XX__"/>
-									<listOptionValue builtIn="false" value="__NEWLIB__"/>
-								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.141099223" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
 								<option id="gnu.c.compiler.option.misc.other.1648232258" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.393058151" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.1642212878" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>

--- a/actuators/blind-shutter/rol-jal-bim112/.cproject
+++ b/actuators/blind-shutter/rol-jal-bim112/.cproject
@@ -2,7 +2,7 @@
 <?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
 	<storageModule moduleId="org.eclipse.cdt.core.settings">
 		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1896956369">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1896956369" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1896956369" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 4ch">
 				<macros>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
@@ -18,7 +18,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Release Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1896956369" name="Flashstart 0x3000 Release" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Release 4ch Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1896956369" name="Flashstart 0x3000 Release 4ch" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
 					<folderInfo id="com.crt.advproject.config.exe.release.914587829.1896956369." name="/" resourcePath="">
 						<toolChain id="com.crt.advproject.toolchain.exe.release.88746451" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.release">
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.1689153735" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
@@ -86,7 +86,7 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.1412464425" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
 								<option id="com.crt.advproject.link.cpp.arch.831237133" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.cpp.thumb.1736533252" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.crt.advproject.link.cpp.script.209271035" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Release.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.script.209271035" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Release_4ch.ld" valueType="string"/>
 								<option id="com.crt.advproject.link.cpp.manage.5680523" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="gnu.cpp.link.option.nostdlibs.617680177" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.1825462087" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
@@ -131,7 +131,7 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 		<cconfiguration id="com.crt.advproject.config.exe.debug.462531644.949451388">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.462531644.949451388" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Debug">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.462531644.949451388" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Debug 4ch">
 				<macros>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
@@ -147,7 +147,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Debug Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.debug.462531644.949451388" name="Flashstart 0x3000 Debug" parent="com.crt.advproject.config.exe.debug" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Debug 4ch Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.debug.462531644.949451388" name="Flashstart 0x3000 Debug 4ch" parent="com.crt.advproject.config.exe.debug" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
 					<folderInfo id="com.crt.advproject.config.exe.debug.462531644.949451388." name="/" resourcePath="">
 						<toolChain id="com.crt.advproject.toolchain.exe.debug.1371580447" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.debug">
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.debug.761645447" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.exe.debug"/>
@@ -212,7 +212,7 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.1349570065" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
 								<option id="com.crt.advproject.link.cpp.arch.1439875131" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.cpp.thumb.172416230" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.crt.advproject.link.cpp.script.2003213227" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Debug.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.script.2003213227" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Debug_4ch.ld" valueType="string"/>
 								<option id="com.crt.advproject.link.cpp.manage.662067093" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="gnu.cpp.link.option.nostdlibs.1474234616" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.583820795" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
@@ -254,7 +254,7 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1562185654">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654" moduleId="org.eclipse.cdt.core.settings" name="Release bf ha">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654" moduleId="org.eclipse.cdt.core.settings" name="Release 4ch bf ha">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
@@ -272,7 +272,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Release rol-jal busfail hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654" name="Release bf ha" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Release 4ch busfail hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654" name="Release 4ch bf ha" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
 					<folderInfo id="com.crt.advproject.config.exe.release.914587829.1562185654." name="/" resourcePath="">
 						<toolChain id="com.crt.advproject.toolchain.exe.release.979749548" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.release">
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.932563479" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
@@ -344,7 +344,7 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.1438104110" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
 								<option id="com.crt.advproject.link.cpp.arch.1855233228" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.cpp.thumb.811541676" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.crt.advproject.link.cpp.script.896038966" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Release_bf_ha.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.script.896038966" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Release_4ch_bf_ha.ld" valueType="string"/>
 								<option id="com.crt.advproject.link.cpp.manage.134464620" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="gnu.cpp.link.option.nostdlibs.432626191" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.1450699020" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
@@ -389,7 +389,7 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 		<cconfiguration id="com.crt.advproject.config.exe.debug.462531644.944556552">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.462531644.944556552" moduleId="org.eclipse.cdt.core.settings" name="Debug bf ha">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.462531644.944556552" moduleId="org.eclipse.cdt.core.settings" name="Debug 4ch bf ha">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
@@ -407,7 +407,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Debug rol-jal busfail hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.debug.462531644.944556552" name="Debug bf ha" parent="com.crt.advproject.config.exe.debug" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Debug 4ch busfail hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.debug.462531644.944556552" name="Debug 4ch bf ha" parent="com.crt.advproject.config.exe.debug" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
 					<folderInfo id="com.crt.advproject.config.exe.debug.462531644.944556552." name="/" resourcePath="">
 						<toolChain id="com.crt.advproject.toolchain.exe.debug.1785751812" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.debug">
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.debug.757599762" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.exe.debug"/>
@@ -473,7 +473,7 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.287595187" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
 								<option id="com.crt.advproject.link.cpp.arch.1987372727" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.cpp.thumb.1632711108" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.crt.advproject.link.cpp.script.1281405068" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Debug_bf_ha.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.script.1281405068" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Debug_4ch_bf_ha.ld" valueType="string"/>
 								<option id="com.crt.advproject.link.cpp.manage.951937494" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="gnu.cpp.link.option.nostdlibs.602135828" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.1229370147" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
@@ -517,7 +517,7 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release bf ha">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 4ch bf ha">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
@@ -535,7 +535,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Release rol-jal busfail hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482" name="Flashstart 0x3000 Release bf ha" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Release 4ch busfail hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482" name="Flashstart 0x3000 Release 4ch bf ha" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
 					<folderInfo id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482." name="/" resourcePath="">
 						<toolChain id="com.crt.advproject.toolchain.exe.release.30700356" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.release">
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.485411571" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
@@ -607,7 +607,7 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.1681976457" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
 								<option id="com.crt.advproject.link.cpp.arch.39188486" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.cpp.thumb.406892592" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.crt.advproject.link.cpp.script.448294001" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Release_bf_ha.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.script.448294001" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Release_4ch_bf_ha.ld" valueType="string"/>
 								<option id="com.crt.advproject.link.cpp.manage.1818878503" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="gnu.cpp.link.option.nostdlibs.701840064" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.1780071868" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
@@ -652,7 +652,7 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release ha">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 4ch ha">
 				<macros>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
@@ -669,7 +669,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Release rol-jal hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702" name="Flashstart 0x3000 Release ha" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Release 4ch hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702" name="Flashstart 0x3000 Release 4ch ha" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
 					<folderInfo id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702." name="/" resourcePath="">
 						<toolChain id="com.crt.advproject.toolchain.exe.release.1194449884" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.release">
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.1455840221" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
@@ -741,7 +741,7 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.1746140209" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
 								<option id="com.crt.advproject.link.cpp.arch.1912290446" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.cpp.thumb.247329708" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.crt.advproject.link.cpp.script.871604405" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Release_ha.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.script.871604405" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Release_4ch_ha.ld" valueType="string"/>
 								<option id="com.crt.advproject.link.cpp.manage.102741268" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="gnu.cpp.link.option.nostdlibs.2017209870" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.1455990218" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
@@ -786,7 +786,7 @@
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366">
-			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366" moduleId="org.eclipse.cdt.core.settings" name="Release ha">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366" moduleId="org.eclipse.cdt.core.settings" name="Release 4ch ha">
 				<macros>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
@@ -803,7 +803,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Release rol-jal hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366" name="Release ha" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Release 4ch hand Build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366" name="Release 4ch ha" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
 					<folderInfo id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366." name="/" resourcePath="">
 						<toolChain id="com.crt.advproject.toolchain.exe.release.406053283" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.release">
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.1618194933" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
@@ -875,7 +875,7 @@
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.447438926" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
 								<option id="com.crt.advproject.link.cpp.arch.353669574" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.link.cpp.thumb.2066310677" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option id="com.crt.advproject.link.cpp.script.321452337" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Release_ha.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.script.321452337" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Release_4ch_ha.ld" valueType="string"/>
 								<option id="com.crt.advproject.link.cpp.manage.884279242" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option id="gnu.cpp.link.option.nostdlibs.2123375663" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.331891884" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
@@ -957,19 +957,40 @@
 		<configuration configurationName="Flashstart 0x3000 Release ha">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
-		<configuration configurationName="Release ha">
+		<configuration configurationName="Release 4ch bf ha">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
-		<configuration configurationName="Flashstart 0x3000 Release bf ha">
+		<configuration configurationName="Debug 4ch bf ha">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Flashstart 0x3000 Release 4ch ha">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
 		<configuration configurationName="Flashstart 0x3000 Release">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
-		<configuration configurationName="Flashstart 0x3000 Debug">
+		<configuration configurationName="Debug bf ha">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
-		<configuration configurationName="Debug bf ha">
+		<configuration configurationName="Release 4ch ha">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Release ha">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Flashstart 0x3000 Release 4ch">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Flashstart 0x3000 Debug 4ch">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Flashstart 0x3000 Release bf ha">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Flashstart 0x3000 Release 4ch bf ha">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Flashstart 0x3000 Debug">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
 		<configuration configurationName="Release">

--- a/actuators/blind-shutter/rol-jal-bim112/.cproject
+++ b/actuators/blind-shutter/rol-jal-bim112/.cproject
@@ -5,8 +5,8 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1896956369" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 4ch">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -135,8 +135,8 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.462531644.949451388" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Debug 4ch">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -259,8 +259,8 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654" moduleId="org.eclipse.cdt.core.settings" name="Release 4ch bf ha">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -391,8 +391,8 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.462531644.944556552" moduleId="org.eclipse.cdt.core.settings" name="Debug 4ch bf ha">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -516,8 +516,8 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 4ch bf ha">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
-					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -648,8 +648,8 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1421299482.188398702" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 4ch ha">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -780,8 +780,8 @@
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1615365366" moduleId="org.eclipse.cdt.core.settings" name="Release 4ch ha">
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
-					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>

--- a/actuators/blind-shutter/rol-jal-bim112/.cproject
+++ b/actuators/blind-shutter/rol-jal-bim112/.cproject
@@ -237,6 +237,7 @@
 								<option id="com.crt.advproject.link.memory.data.cpp.451875320" name="Global data placement" superClass="com.crt.advproject.link.memory.data.cpp" useByScannerDiscovery="false" value="Default" valueType="string"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.memory.sections.cpp.1217509933" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections.cpp" useByScannerDiscovery="false" valueType="stringList"/>
 								<option defaultValue="com.crt.advproject.heapAndStack.lpcXpressoStyle.cpp" id="com.crt.advproject.link.memory.heapAndStack.style.cpp.1420157016" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style.cpp" useByScannerDiscovery="false" value="com.crt.advproject.heapAndStack.lpcXpressoStyle.cpp" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.multicore.master.1445122783" name="Multicore master" superClass="com.crt.advproject.link.cpp.multicore.master"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.850970854" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
@@ -908,6 +909,395 @@
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
+		<cconfiguration id="com.crt.advproject.config.exe.debug.462531644.944556552.388916654">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.462531644.944556552.388916654" moduleId="org.eclipse.cdt.core.settings" name="Debug 8ch bf">
+				<macros>
+					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="8"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
+				</macros>
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GNU_ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Debug 8ch busfail build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.debug.462531644.944556552.388916654" name="Debug 8ch bf" parent="com.crt.advproject.config.exe.debug" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+					<folderInfo id="com.crt.advproject.config.exe.debug.462531644.944556552.388916654." name="/" resourcePath="">
+						<toolChain id="com.crt.advproject.toolchain.exe.debug.1346036367" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.debug">
+							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.debug.1548987311" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.exe.debug"/>
+							<builder buildPath="${workspace_loc:/rol-jal-bim112}/Debug" id="com.crt.advproject.builder.exe.debug.850480575" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.exe.debug"/>
+							<tool id="com.crt.advproject.cpp.exe.debug.987757601" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.debug">
+								<option id="com.crt.advproject.cpp.arch.536391132" name="Architecture" superClass="com.crt.advproject.cpp.arch" useByScannerDiscovery="true" value="com.crt.advproject.cpp.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.thumb.282502388" name="Thumb mode" superClass="com.crt.advproject.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.1691248636" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+									<listOptionValue builtIn="false" value="DEBUG"/>
+									<listOptionValue builtIn="false" value="CORE_M0"/>
+									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
+									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
+									<listOptionValue builtIn="false" value="__LPC11XX__"/>
+									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
+									<listOptionValue builtIn="false" value="${hand_actuation}"/>
+								</option>
+								<option id="gnu.cpp.compiler.option.other.other.2097987460" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
+								<option id="com.crt.advproject.cpp.hdrlib.896028490" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.cpp.hdrlib.newlibnano" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.include.paths.1000859068" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/inc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/app-common}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/sblib/inc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/bus_voltage}&quot;"/>
+								</option>
+								<option id="com.crt.advproject.cpp.exe.debug.option.optimization.level.574591767" name="Optimization Level" superClass="com.crt.advproject.cpp.exe.debug.option.optimization.level" useByScannerDiscovery="true" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.fpu.1512753975" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true"/>
+								<option id="com.crt.advproject.cpp.specs.1288049675" name="Specs" superClass="com.crt.advproject.cpp.specs" useByScannerDiscovery="false" value="com.crt.advproject.cpp.specs.newlibnano" valueType="enumerated"/>
+								<inputType id="com.crt.advproject.compiler.cpp.input.1664404292" superClass="com.crt.advproject.compiler.cpp.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gcc.exe.debug.1730669520" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug">
+								<option id="com.crt.advproject.gcc.hdrlib.1270076378" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.arch.200086008" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.thumb.541529678" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1415388909" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
+								<option id="gnu.c.compiler.option.misc.other.1993772150" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
+								<option id="gnu.c.compiler.option.include.paths.1243803087" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.846603232" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="true" value="gnu.c.optimization.level.none" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.specs.118294697" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
+								<inputType id="com.crt.advproject.compiler.input.940626365" superClass="com.crt.advproject.compiler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gas.exe.debug.267757845" name="MCU Assembler" superClass="com.crt.advproject.gas.exe.debug">
+								<option id="com.crt.advproject.gas.hdrlib.1922772853" name="Library headers" superClass="com.crt.advproject.gas.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gas.hdrlib.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.arch.739694014" name="Architecture" superClass="com.crt.advproject.gas.arch" useByScannerDiscovery="false" value="com.crt.advproject.gas.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.thumb.306481892" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.both.asm.option.flags.crt.1191897976" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" useByScannerDiscovery="false" value="-c -x assembler-with-cpp -DNDEBUG -DCORE_M0 -D__USE_CMSIS=CMSIS_CORE_LPC11xx -D__LPC11XX__ -D__NEWLIB__" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.1130284108" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/inc}&quot;"/>
+								</option>
+								<option id="com.crt.advproject.gas.specs.81496880" name="Specs" superClass="com.crt.advproject.gas.specs" useByScannerDiscovery="false" value="com.crt.advproject.gas.specs.newlibnano" valueType="enumerated"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.2033984115" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="com.crt.advproject.assembler.input.532805119" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.link.cpp.exe.debug.429596261" name="MCU C++ Linker" superClass="com.crt.advproject.link.cpp.exe.debug">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.786191910" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
+								<option id="com.crt.advproject.link.cpp.arch.1766899829" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.thumb.484108925" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.script.1487879849" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Debug_8ch_bf.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.manage.1666643236" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.link.option.nostdlibs.490097837" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.358303837" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value="-Map=&quot;${BuildArtifactFileBaseName}.map&quot;"/>
+									<listOptionValue builtIn="false" value="--gc-sections"/>
+								</option>
+								<option id="com.crt.advproject.link.cpp.hdrlib.2063080919" name="Library" superClass="com.crt.advproject.link.cpp.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.cpp.link.hdrlib.newlibnano.nohost" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.libs.502713164" name="Libraries (-l)" superClass="gnu.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="CMSIS_CORE_LPC11xx"/>
+									<listOptionValue builtIn="false" value="sblib"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.paths.1850330555" name="Library search path (-L)" superClass="gnu.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/Debug}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/sblib/Release}&quot;"/>
+								</option>
+								<option id="com.crt.advproject.link.cpp.crpenable.312609632" name="Enable automatic placement of Code Read Protection field in image" superClass="com.crt.advproject.link.cpp.crpenable" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.multicore.slave.858608201" name="Multicore configuration" superClass="com.crt.advproject.link.cpp.multicore.slave" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.link.memory.load.image.cpp.728175094" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image.cpp" useByScannerDiscovery="false" value="false;" valueType="string"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.cpp.1167136261" name="Heap and Stack options" superClass="com.crt.advproject.link.memory.heapAndStack.cpp" useByScannerDiscovery="false" value="&amp;Heap:Default;Post Data;Default&amp;Stack:Default;End;Default" valueType="string"/>
+								<option id="com.crt.advproject.link.memory.data.cpp.723353079" name="Global data placement" superClass="com.crt.advproject.link.memory.data.cpp" useByScannerDiscovery="false" value="Default" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.memory.sections.cpp.913638914" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections.cpp" useByScannerDiscovery="false" valueType="stringList"/>
+								<option defaultValue="com.crt.advproject.heapAndStack.lpcXpressoStyle.cpp" id="com.crt.advproject.link.memory.heapAndStack.style.cpp.13780092" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style.cpp" useByScannerDiscovery="false" value="com.crt.advproject.heapAndStack.lpcXpressoStyle.cpp" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.lto.1273595783" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.link.cpp.lto" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.multicore.master.2123076107" name="Multicore master" superClass="com.crt.advproject.link.cpp.multicore.master"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.1673268605" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="com.crt.advproject.link.exe.debug.1947520427" name="MCU Linker" superClass="com.crt.advproject.link.exe.debug">
+								<option id="com.crt.advproject.link.gcc.hdrlib.173758126" name="Library" superClass="com.crt.advproject.link.gcc.hdrlib"/>
+							</tool>
+							<tool id="com.crt.advproject.tool.debug.debug.1596675694" name="MCU Debugger" superClass="com.crt.advproject.tool.debug.debug"/>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry excluding="hand_actuation.cpp" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="src"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1562185654.1260537717">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1260537717" moduleId="org.eclipse.cdt.core.settings" name="Release 8ch bf">
+				<macros>
+					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="8"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
+				</macros>
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GNU_ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Release 8ch busfail build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654.1260537717" name="Release 8ch bf" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+					<folderInfo id="com.crt.advproject.config.exe.release.914587829.1562185654.1260537717." name="/" resourcePath="">
+						<toolChain id="com.crt.advproject.toolchain.exe.release.33414282" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.release">
+							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.1626804197" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
+							<builder autoBuildTarget="all" buildPath="${workspace_loc:/rol-jal-bim112}/Release" cleanBuildTarget="clean" enableAutoBuild="false" enableCleanBuild="true" enabledIncrementalBuild="true" id="com.crt.advproject.builder.exe.release.1216250337" incrementalBuildTarget="all" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.crt.advproject.builder.exe.release"/>
+							<tool id="com.crt.advproject.cpp.exe.release.202706880" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.release">
+								<option id="com.crt.advproject.cpp.arch.377695689" name="Architecture" superClass="com.crt.advproject.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.cpp.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.thumb.615359606" name="Thumb mode" superClass="com.crt.advproject.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.986121564" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+									<listOptionValue builtIn="false" value="NDEBUG"/>
+									<listOptionValue builtIn="false" value="CORE_M0"/>
+									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
+									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
+									<listOptionValue builtIn="false" value="__LPC11XX__"/>
+									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
+									<listOptionValue builtIn="false" value="${hand_actuation}"/>
+								</option>
+								<option id="gnu.cpp.compiler.option.other.other.541280573" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
+								<option id="gnu.cpp.compiler.option.optimization.flags.366699041" name="Other optimization flags" superClass="gnu.cpp.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="com.crt.advproject.cpp.hdrlib.1720414161" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.cpp.hdrlib.newlibnano" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.include.paths.340241186" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/inc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/app-common}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/bus_voltage}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/sblib/inc}&quot;"/>
+								</option>
+								<option id="gnu.cpp.compiler.option.include.files.1792356636" name="Include files (-include)" superClass="gnu.cpp.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.fpu.122106405" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true"/>
+								<option id="com.crt.advproject.cpp.lto.138258658" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.cpp.lto" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.cpp.exe.release.option.debugging.level.193518114" name="Debug Level" superClass="com.crt.advproject.cpp.exe.release.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.specs.37636812" name="Specs" superClass="com.crt.advproject.cpp.specs" useByScannerDiscovery="false" value="com.crt.advproject.cpp.specs.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.exe.release.option.optimization.level.1709769475" name="Optimization Level" superClass="com.crt.advproject.cpp.exe.release.option.optimization.level" useByScannerDiscovery="true"/>
+								<inputType id="com.crt.advproject.compiler.cpp.input.2068197509" superClass="com.crt.advproject.compiler.cpp.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gcc.exe.release.1581742776" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.release">
+								<option id="com.crt.advproject.gcc.hdrlib.350890076" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.arch.245469413" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.thumb.1561398935" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.113057043" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
+								<option id="gnu.c.compiler.option.misc.other.1058632053" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
+								<option id="gnu.c.compiler.option.include.paths.353982589" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.specs.1114386378" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.lto.1720246305" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.gcc.lto" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gcc.exe.release.option.debugging.level.1141241538" name="Debug Level" superClass="com.crt.advproject.gcc.exe.release.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.optimization.flags.355569827" name="Other optimization flags" superClass="gnu.c.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<inputType id="com.crt.advproject.compiler.input.928580010" superClass="com.crt.advproject.compiler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gas.exe.release.508042513" name="MCU Assembler" superClass="com.crt.advproject.gas.exe.release">
+								<option id="com.crt.advproject.gas.hdrlib.1265332345" name="Library headers" superClass="com.crt.advproject.gas.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gas.hdrlib.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.arch.1536930850" name="Architecture" superClass="com.crt.advproject.gas.arch" useByScannerDiscovery="false" value="com.crt.advproject.gas.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.thumb.235692049" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.both.asm.option.flags.crt.531603395" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" useByScannerDiscovery="false" value="-c -x assembler-with-cpp -DNDEBUG -DCORE_M0 -D__USE_CMSIS=CMSIS_CORE_LPC11xx -D__LPC11XX__ -D__NEWLIB__" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.893496668" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/inc}&quot;"/>
+								</option>
+								<option id="com.crt.advproject.gas.specs.1152751670" name="Specs" superClass="com.crt.advproject.gas.specs" useByScannerDiscovery="false" value="com.crt.advproject.gas.specs.newlibnano" valueType="enumerated"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.1730485380" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="com.crt.advproject.assembler.input.293311746" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.link.cpp.exe.release.1922127153" name="MCU C++ Linker" superClass="com.crt.advproject.link.cpp.exe.release">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.608178623" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
+								<option id="com.crt.advproject.link.cpp.arch.1026308127" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.thumb.1662303492" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.script.836955220" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Release_8ch_bf.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.manage.1173259323" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.link.option.nostdlibs.45641614" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.859993763" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value="-Map=&quot;${BuildArtifactFileBaseName}.map&quot;"/>
+									<listOptionValue builtIn="false" value="--gc-sections"/>
+								</option>
+								<option id="com.crt.advproject.link.cpp.hdrlib.1197028337" name="Library" superClass="com.crt.advproject.link.cpp.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.cpp.link.hdrlib.newlibnano.nohost" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.libs.565902916" name="Libraries (-l)" superClass="gnu.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="CMSIS_CORE_LPC11xx"/>
+									<listOptionValue builtIn="false" value="sblib"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.paths.990623252" name="Library search path (-L)" superClass="gnu.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/Release}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/sblib/Release}&quot;"/>
+								</option>
+								<option id="com.crt.advproject.link.cpp.crpenable.2109432927" name="Enable automatic placement of Code Read Protection field in image" superClass="com.crt.advproject.link.cpp.crpenable" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.multicore.slave.845950976" name="Multicore configuration" superClass="com.crt.advproject.link.cpp.multicore.slave" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.link.memory.load.image.cpp.26666261" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image.cpp" useByScannerDiscovery="false" value="false;" valueType="string"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.cpp.1218981533" name="Heap and Stack options" superClass="com.crt.advproject.link.memory.heapAndStack.cpp" useByScannerDiscovery="false" value="&amp;Heap:Default;Post Data;Default&amp;Stack:Default;End;Default" valueType="string"/>
+								<option id="com.crt.advproject.link.memory.data.cpp.1146922316" name="Global data placement" superClass="com.crt.advproject.link.memory.data.cpp" useByScannerDiscovery="false" value="Default" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.memory.sections.cpp.1170708443" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections.cpp" useByScannerDiscovery="false" valueType="stringList"/>
+								<option defaultValue="com.crt.advproject.heapAndStack.lpcXpressoStyle.cpp" id="com.crt.advproject.link.memory.heapAndStack.style.cpp.2102426840" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style.cpp" useByScannerDiscovery="false" value="com.crt.advproject.heapAndStack.lpcXpressoStyle.cpp" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.lto.390649462" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.link.cpp.lto" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.lto.optmization.level.81452493" name="Link-time optimization level" superClass="com.crt.advproject.link.cpp.lto.optmization.level" useByScannerDiscovery="false" value="link.cpp.optimization.level.size" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.multicore.master.972171909" name="Multicore master" superClass="com.crt.advproject.link.cpp.multicore.master"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.2021148787" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="com.crt.advproject.link.exe.release.1438277821" name="MCU Linker" superClass="com.crt.advproject.link.exe.release">
+								<option id="com.crt.advproject.link.gcc.hdrlib.310872358" name="Library" superClass="com.crt.advproject.link.gcc.hdrlib"/>
+							</tool>
+							<tool id="com.crt.advproject.tool.debug.release.304568990" name="MCU Debugger" superClass="com.crt.advproject.tool.debug.release"/>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry excluding="hand_actuation.cpp" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="src"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+		<cconfiguration id="com.crt.advproject.config.exe.release.914587829.1562185654.1260537717.1260188751">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.914587829.1562185654.1260537717.1260188751" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release 8ch bf">
+				<macros>
+					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="8"/>
+					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
+				</macros>
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GNU_ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactExtension="axf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe" cleanCommand="rm -rf" description="Flashstart 0x3000 Release 8ch busfail build" errorParsers="org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GCCErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.GASErrorParser" id="com.crt.advproject.config.exe.release.914587829.1562185654.1260537717.1260188751" name="Flashstart 0x3000 Release 8ch bf" parent="com.crt.advproject.config.exe.release" postannouncebuildStep="Performing post-build steps" postbuildStep="&quot;${ProjDirPath}/../../../script/build-script/post-build-steps.sh&quot; &quot;${CWD}&quot; &quot;${TargetChip}&quot; &quot;${BuildArtifactFileName}&quot; &quot;${BuildArtifactFileBaseName}&quot; &quot;${ConfigName}&quot; &quot;${sw_version}&quot; &quot;${hexDir}&quot;">
+					<folderInfo id="com.crt.advproject.config.exe.release.914587829.1562185654.1260537717.1260188751." name="/" resourcePath="">
+						<toolChain id="com.crt.advproject.toolchain.exe.release.1391421246" name="Code Red MCU Tools" superClass="com.crt.advproject.toolchain.exe.release">
+							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.394125203" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
+							<builder autoBuildTarget="all" buildPath="${workspace_loc:/rol-jal-bim112}/Release" cleanBuildTarget="clean" enableAutoBuild="false" enableCleanBuild="true" enabledIncrementalBuild="true" id="com.crt.advproject.builder.exe.release.1021428849" incrementalBuildTarget="all" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="com.crt.advproject.builder.exe.release"/>
+							<tool id="com.crt.advproject.cpp.exe.release.860250691" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.release">
+								<option id="com.crt.advproject.cpp.arch.351409574" name="Architecture" superClass="com.crt.advproject.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.cpp.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.thumb.947114822" name="Thumb mode" superClass="com.crt.advproject.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.2145662333" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+									<listOptionValue builtIn="false" value="NDEBUG"/>
+									<listOptionValue builtIn="false" value="CORE_M0"/>
+									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
+									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
+									<listOptionValue builtIn="false" value="__LPC11XX__"/>
+									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
+									<listOptionValue builtIn="false" value="${hand_actuation}"/>
+								</option>
+								<option id="gnu.cpp.compiler.option.other.other.727291677" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
+								<option id="gnu.cpp.compiler.option.optimization.flags.2128997369" name="Other optimization flags" superClass="gnu.cpp.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<option id="com.crt.advproject.cpp.hdrlib.545510728" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.cpp.hdrlib.newlibnano" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.include.paths.1850192277" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/inc}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/app-common}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/src/bus_voltage}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/sblib/inc}&quot;"/>
+								</option>
+								<option id="gnu.cpp.compiler.option.include.files.890274077" name="Include files (-include)" superClass="gnu.cpp.compiler.option.include.files" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.cpp.fpu.1403873576" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true"/>
+								<option id="com.crt.advproject.cpp.lto.2029844741" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.cpp.lto" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.cpp.exe.release.option.debugging.level.1735981888" name="Debug Level" superClass="com.crt.advproject.cpp.exe.release.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.none" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.specs.1956610977" name="Specs" superClass="com.crt.advproject.cpp.specs" useByScannerDiscovery="false" value="com.crt.advproject.cpp.specs.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.cpp.exe.release.option.optimization.level.760078011" name="Optimization Level" superClass="com.crt.advproject.cpp.exe.release.option.optimization.level" useByScannerDiscovery="true"/>
+								<inputType id="com.crt.advproject.compiler.cpp.input.1432288551" superClass="com.crt.advproject.compiler.cpp.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gcc.exe.release.1040167381" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.release">
+								<option id="com.crt.advproject.gcc.hdrlib.1089135157" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.arch.1023375638" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.thumb.915538700" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.144527984" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
+								<option id="gnu.c.compiler.option.misc.other.281459483" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
+								<option id="gnu.c.compiler.option.include.paths.1135705392" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.gcc.specs.641662729" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.gcc.lto.1970558903" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.gcc.lto" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.gcc.exe.release.option.debugging.level.605447800" name="Debug Level" superClass="com.crt.advproject.gcc.exe.release.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.none" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.optimization.flags.1952695563" name="Other optimization flags" superClass="gnu.c.compiler.option.optimization.flags" useByScannerDiscovery="false" value="-fno-common" valueType="string"/>
+								<inputType id="com.crt.advproject.compiler.input.659754484" superClass="com.crt.advproject.compiler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.gas.exe.release.1707444553" name="MCU Assembler" superClass="com.crt.advproject.gas.exe.release">
+								<option id="com.crt.advproject.gas.hdrlib.1677927195" name="Library headers" superClass="com.crt.advproject.gas.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gas.hdrlib.newlibnano" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.arch.1151602426" name="Architecture" superClass="com.crt.advproject.gas.arch" useByScannerDiscovery="false" value="com.crt.advproject.gas.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.gas.thumb.2035419971" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.both.asm.option.flags.crt.1522120736" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" useByScannerDiscovery="false" value="-c -x assembler-with-cpp -DNDEBUG -DCORE_M0 -D__USE_CMSIS=CMSIS_CORE_LPC11xx -D__LPC11XX__ -D__NEWLIB__" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.135635165" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/inc}&quot;"/>
+								</option>
+								<option id="com.crt.advproject.gas.specs.397778173" name="Specs" superClass="com.crt.advproject.gas.specs" useByScannerDiscovery="false" value="com.crt.advproject.gas.specs.newlibnano" valueType="enumerated"/>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.904028577" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+								<inputType id="com.crt.advproject.assembler.input.1829900779" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
+							</tool>
+							<tool id="com.crt.advproject.link.cpp.exe.release.2107253545" name="MCU C++ Linker" superClass="com.crt.advproject.link.cpp.exe.release">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.cpp.multicore.master.userobjs.53531413" name="Slave Objects (not visible)" superClass="com.crt.advproject.link.cpp.multicore.master.userobjs" useByScannerDiscovery="false" valueType="userObjs"/>
+								<option id="com.crt.advproject.link.cpp.arch.1529749524" name="Architecture" superClass="com.crt.advproject.link.cpp.arch" useByScannerDiscovery="false" value="com.crt.advproject.link.cpp.target.cm0" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.thumb.285578718" name="Thumb mode" superClass="com.crt.advproject.link.cpp.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.script.1650554816" name="Linker script" superClass="com.crt.advproject.link.cpp.script" useByScannerDiscovery="false" value="rol-jal-bim112_Flashstart_0x3000_Release_8ch_bf.ld" valueType="string"/>
+								<option id="com.crt.advproject.link.cpp.manage.1831103531" name="Manage linker script" superClass="com.crt.advproject.link.cpp.manage" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="gnu.cpp.link.option.nostdlibs.513950367" name="No startup or default libs (-nostdlib)" superClass="gnu.cpp.link.option.nostdlibs" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.other.482315599" name="Other options (-Xlinker [option])" superClass="gnu.cpp.link.option.other" useByScannerDiscovery="false" valueType="stringList">
+									<listOptionValue builtIn="false" value="-Map=&quot;${BuildArtifactFileBaseName}.map&quot;"/>
+									<listOptionValue builtIn="false" value="--gc-sections"/>
+								</option>
+								<option id="com.crt.advproject.link.cpp.hdrlib.624579597" name="Library" superClass="com.crt.advproject.link.cpp.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.cpp.link.hdrlib.newlibnano.nohost" valueType="enumerated"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.libs.962943576" name="Libraries (-l)" superClass="gnu.cpp.link.option.libs" useByScannerDiscovery="false" valueType="libs">
+									<listOptionValue builtIn="false" value="CMSIS_CORE_LPC11xx"/>
+									<listOptionValue builtIn="false" value="sblib"/>
+								</option>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.link.option.paths.948884050" name="Library search path (-L)" superClass="gnu.cpp.link.option.paths" useByScannerDiscovery="false" valueType="libPaths">
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/CMSIS_CORE_LPC11xx/Release}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/sblib/Release}&quot;"/>
+								</option>
+								<option id="com.crt.advproject.link.cpp.crpenable.1540055130" name="Enable automatic placement of Code Read Protection field in image" superClass="com.crt.advproject.link.cpp.crpenable" useByScannerDiscovery="false" value="false" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.multicore.slave.1690134528" name="Multicore configuration" superClass="com.crt.advproject.link.cpp.multicore.slave" useByScannerDiscovery="false"/>
+								<option id="com.crt.advproject.link.memory.load.image.cpp.1039197073" name="Plain load image" superClass="com.crt.advproject.link.memory.load.image.cpp" useByScannerDiscovery="false" value="false;" valueType="string"/>
+								<option id="com.crt.advproject.link.memory.heapAndStack.cpp.1893871209" name="Heap and Stack options" superClass="com.crt.advproject.link.memory.heapAndStack.cpp" useByScannerDiscovery="false" value="&amp;Heap:Default;Post Data;Default&amp;Stack:Default;End;Default" valueType="string"/>
+								<option id="com.crt.advproject.link.memory.data.cpp.1211757809" name="Global data placement" superClass="com.crt.advproject.link.memory.data.cpp" useByScannerDiscovery="false" value="Default" valueType="string"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="com.crt.advproject.link.memory.sections.cpp.1811199529" name="Extra linker script input sections" superClass="com.crt.advproject.link.memory.sections.cpp" useByScannerDiscovery="false" valueType="stringList"/>
+								<option defaultValue="com.crt.advproject.heapAndStack.lpcXpressoStyle.cpp" id="com.crt.advproject.link.memory.heapAndStack.style.cpp.338756878" name="Heap and Stack placement" superClass="com.crt.advproject.link.memory.heapAndStack.style.cpp" useByScannerDiscovery="false" value="com.crt.advproject.heapAndStack.lpcXpressoStyle.cpp" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.lto.516222057" name="Enable Link-time optimization (-flto)" superClass="com.crt.advproject.link.cpp.lto" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.crt.advproject.link.cpp.lto.optmization.level.1755186369" name="Link-time optimization level" superClass="com.crt.advproject.link.cpp.lto.optmization.level" useByScannerDiscovery="false" value="link.cpp.optimization.level.size" valueType="enumerated"/>
+								<option id="com.crt.advproject.link.cpp.multicore.master.1470825937" name="Multicore master" superClass="com.crt.advproject.link.cpp.multicore.master"/>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.680801071" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="com.crt.advproject.link.exe.release.1657432146" name="MCU Linker" superClass="com.crt.advproject.link.exe.release">
+								<option id="com.crt.advproject.link.gcc.hdrlib.1987402676" name="Library" superClass="com.crt.advproject.link.gcc.hdrlib"/>
+							</tool>
+							<tool id="com.crt.advproject.tool.debug.release.72916432" name="MCU Debugger" superClass="com.crt.advproject.tool.debug.release"/>
+						</toolChain>
+					</folderInfo>
+					<sourceEntries>
+						<entry excluding="hand_actuation.cpp" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="src"/>
+					</sourceEntries>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="rol-jal-bim112.com.crt.advproject.projecttype.exe.296190825" name="Executable" projectType="com.crt.advproject.projecttype.exe"/>
@@ -968,6 +1358,9 @@
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
 		<configuration configurationName="Flashstart 0x3000 Release 4ch">
+			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
+		</configuration>
+		<configuration configurationName="Debug 8ch bf">
 			<resource resourceType="PROJECT" workspacePath="/rol-jal-bim112"/>
 		</configuration>
 		<configuration configurationName="Flashstart 0x3000 Debug 4ch">

--- a/actuators/blind-shutter/rol-jal-bim112/.cproject
+++ b/actuators/blind-shutter/rol-jal-bim112/.cproject
@@ -6,7 +6,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
-					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -37,7 +37,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
-									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1488163135" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -136,7 +136,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value=""/>
-					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -167,7 +167,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
-									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.334141329" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -260,7 +260,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
-					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -291,7 +291,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
-									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1060283852" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -392,7 +392,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
-					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -423,7 +423,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
-									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1149195404" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -517,7 +517,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value="BUSFAIL"/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
-					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -548,7 +548,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
-									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1570334820" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -649,7 +649,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
-					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -680,7 +680,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
-									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1262110196" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -781,7 +781,7 @@
 				<macros>
 					<stringMacro name="bus_fail" type="VALUE_TEXT" value=""/>
 					<stringMacro name="hand_actuation" type="VALUE_TEXT" value="HAND_ACTUATION"/>
-					<stringMacro name="channel_number" type="VALUE_TEXT" value="4"/>
+					<stringMacro name="channel_count" type="VALUE_TEXT" value="4"/>
 					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
@@ -812,7 +812,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
-									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="CHANNEL_COUNT=${channel_count}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.340050550" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>

--- a/actuators/blind-shutter/rol-jal-bim112/.cproject
+++ b/actuators/blind-shutter/rol-jal-bim112/.cproject
@@ -36,6 +36,9 @@
 									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
+									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1488163135" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
 								<option id="gnu.cpp.compiler.option.optimization.flags.478391290" name="Other optimization flags" superClass="gnu.cpp.compiler.option.optimization.flags" useByScannerDiscovery="false" value="" valueType="string"/>
@@ -58,7 +61,9 @@
 								<option id="com.crt.advproject.gcc.hdrlib.479871198" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.1906086949" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.2101199042" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.189510947" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.189510947" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
 								<option id="gnu.c.compiler.option.misc.other.1787083313" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1759788236" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.850666333" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
@@ -161,6 +166,9 @@
 									<listOptionValue builtIn="false" value="__USE_CMSIS=CMSIS_CORE_LPC11xx"/>
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
+									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="${channel_number}"/>
+									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.334141329" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
 								<option id="com.crt.advproject.cpp.hdrlib.903853161" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.cpp.hdrlib.newlibnano" valueType="enumerated"/>
@@ -181,7 +189,9 @@
 								<option id="com.crt.advproject.gcc.hdrlib.19748687" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.264800783" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.1613793461" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.766097537" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.766097537" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
 								<option id="gnu.c.compiler.option.misc.other.1772127924" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.450793783" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1508961380" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="true" value="gnu.c.optimization.level.none" valueType="enumerated"/>
@@ -281,6 +291,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="${channel_number}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1060283852" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -305,7 +316,9 @@
 								<option id="com.crt.advproject.gcc.hdrlib.1104869415" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.295478681" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.887910703" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1569765939" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1569765939" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
 								<option id="gnu.c.compiler.option.misc.other.108724202" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1449864096" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.1108361002" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
@@ -410,6 +423,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="${channel_number}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1149195404" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -430,7 +444,9 @@
 								<option id="com.crt.advproject.gcc.hdrlib.922923008" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.931902619" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.2114019256" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.1719292716" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.1719292716" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
 								<option id="gnu.c.compiler.option.misc.other.196339483" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1395647897" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.968211388" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="true" value="gnu.c.optimization.level.none" valueType="enumerated"/>
@@ -532,6 +548,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="${channel_number}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1570334820" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -556,7 +573,9 @@
 								<option id="com.crt.advproject.gcc.hdrlib.2033175474" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.1364703739" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.115990314" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.897838209" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.897838209" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
 								<option id="gnu.c.compiler.option.misc.other.345424755" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1629737013" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.1233089275" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
@@ -661,6 +680,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="${channel_number}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.1262110196" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -685,7 +705,9 @@
 								<option id="com.crt.advproject.gcc.hdrlib.509148988" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.1327797485" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.2055971673" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.268963728" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.268963728" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
 								<option id="gnu.c.compiler.option.misc.other.402119941" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.1949324127" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.328700878" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>
@@ -790,6 +812,7 @@
 									<listOptionValue builtIn="false" value="CPP_USE_HEAP"/>
 									<listOptionValue builtIn="false" value="__LPC11XX__"/>
 									<listOptionValue builtIn="false" value="${bus_fail}"/>
+									<listOptionValue builtIn="false" value="${channel_number}"/>
 									<listOptionValue builtIn="false" value="${hand_actuation}"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.other.other.340050550" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-rtti -fno-exceptions" valueType="string"/>
@@ -814,7 +837,9 @@
 								<option id="com.crt.advproject.gcc.hdrlib.1026224388" name="Library headers" superClass="com.crt.advproject.gcc.hdrlib" useByScannerDiscovery="false" value="com.crt.advproject.gcc.hdrlib.newlibnano" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.arch.1760880793" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="false" value="com.crt.advproject.gcc.target.cm0" valueType="enumerated"/>
 								<option id="com.crt.advproject.gcc.thumb.940796948" name="Thumb mode" superClass="com.crt.advproject.gcc.thumb" useByScannerDiscovery="false" value="true" valueType="boolean"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="true" id="gnu.c.compiler.option.preprocessor.def.symbols.141099223" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.141099223" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="__NEWLIB__"/>
+								</option>
 								<option id="gnu.c.compiler.option.misc.other.1648232258" name="Other flags" superClass="gnu.c.compiler.option.misc.other" useByScannerDiscovery="false" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections" valueType="string"/>
 								<option id="gnu.c.compiler.option.include.paths.393058151" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false"/>
 								<option id="com.crt.advproject.gcc.specs.1642212878" name="Specs" superClass="com.crt.advproject.gcc.specs" useByScannerDiscovery="false" value="com.crt.advproject.gcc.specs.newlibnano" valueType="enumerated"/>

--- a/actuators/blind-shutter/rol-jal-bim112/README.md
+++ b/actuators/blind-shutter/rol-jal-bim112/README.md
@@ -1,0 +1,92 @@
+## rol-jal-bim112 a 4/8-fold Shutter Actuator, 4/8-fach Jalousieaktor
+
+*english:*  
+This is an application that uses the [sbLib](https://selfbus.org) with BIM112 (Mask 0x0701) emulation.
+The emulated device is a MDT
+- JAL-0410.01 Shutter Actuator 4-fold, 4MU, 230VAC, 10A or 
+- JAL-0810.01 Shutter Actuator 8-fold, 8MU, 230VAC, 10A
+
+Please use the [MDT_KP_Jalousieaktor_V28.knxprod](https://www.mdt.de/fileadmin/user_upload/user_upload/download/Archiv/MDT_KP_Jalousieaktor_V28.knxprod) product database for ETS configuration.
+
+*deutsch:*  
+Das ist eine Applikation welche die [sbLib](https://selfbus.org) mit BIM112 (Mask 0x0701) Emulation verwendet.
+Das simulierte Gerät ist ein MDT
+- JAL-0410.01 Jalousieaktor JAL 4-fach, 4TE, 230VAC, 10A bzw. 
+- JAL-0810.01 Jalousieaktor JAL 8-fach, 8TE, 230VAC, 10A
+
+Zur ETS-Konfiguration die [MDT_KP_Jalousieaktor_V28.knxprod](https://www.mdt.de/fileadmin/user_upload/user_upload/download/Archiv/MDT_KP_Jalousieaktor_V28.knxprod) Produktdatenbank verwenden.
+
+### Build configuration naming (Build-Konfiguration Namen) 
+| Abbreviation<br>Abkürzung | Meaning<br>Bedeutung                                                             |
+|---------------------------|----------------------------------------------------------------------------------|
+| Debug                     | Only for debugging<br>Nur zum debuggen                                           |
+| Flashstart                | For use with the Selfbus bootloader<br>Zur Nutzung mit dem Selfbus Bootloader    |
+| Release                   | Stand alone firmware<br>Lauffähige Firmware ohne Nutzung des Selfbus Bootloaders |
+| 4ch, 8ch                  | Number of channels<br> Anzahl der Kanäle                                         |
+| bf                        | bus-fail / bus voltage detection<br>Busspannungsausfallerkennnung                |
+| ha                        | hand actuation<br>mit Handbedienung                                              |
+
+## 4MU-ARM Controller ([PCB](https://github.com/selfbus/hardware-merged/tree/main/controller_lpc1115/lpc1115_4MU_MID), [Wiki](https://selfbus.org/wiki/hardware/controller/49-4te-controller-arm-lpc1115)) + shutter_4x_4MU ([PCB](https://github.com/selfbus/hardware-merged/tree/main/applications_din/shutter_4x_4MU), [Wiki](https://selfbus.org/wiki/devices/outputs/25-8-fold-binary-output-4module-units-lpc1115))
+### used IO Ports (verwendete IO Ports):
+| Relay # | Channel # | Function | Selfbus IO | Selfbus 26-pol | ARM Port | Description (Beschreibung) |
+|:-------:|-----------|:--------:|:----------:|:--------------:|----------|----------------------------|
+|  REL1   | 1         |  up/auf  |    IO1     |       7        | PIO2_2   |                            |
+|  REL2   | 1         | down/zu  |    IO2     |       8        | PIO0_7   |                            |
+|  REL3   | 2         |  up/auf  |    IO3     |       9        | PIO2_10  |                            |
+|  REL4   | 2         | down/zu  |    IO4     |       10       | PIO2_9   |                            |
+|  REL5   | 3         |  up/auf  |    IO5     |       13       | PIO0_2   |                            |
+|  REL6   | 3         | down/zu  |    IO6     |       14       | PIO0_8   |                            |
+|  REL7   | 4         |  up/auf  |    IO7     |       15       | PIO0_9   |                            |
+|  REL8   | 4         | down/zu  |    IO8     |       16       | PIO2_11  |                            |
+|         |           |          |            |                |          |                            |
+|         |           |   PWM    |  PIN_PWM   |       3        | PIO3_2   | pulse wide modulation      |
+|         |           |   VDD    |            |       6        |          | EIB_DC (R1 680R to VDD)    |
+
+-------------
+
+## 4MU-ARM Controller ([PCB](https://github.com/selfbus/hardware-merged/tree/main/controller_lpc1115/lpc1115_4MU_MID), [Wiki](https://selfbus.org/wiki/hardware/controller/49-4te-controller-arm-lpc1115)) + shutter_8x_xMU (PCB has yet to be created, [Wiki](https://selfbus.org/wiki/devices/outputs/25-8-fold-binary-output-4module-units-lpc1115))
+### proposed IO ports (vorgeschlagene IO Ports):
+| Relay # | Channel # | Function | Selfbus IO | Selfbus 26-pol | ARM Port | Description (Beschreibung) |
+|:-------:|:---------:|:--------:|:----------:|:--------------:|----------|----------------------------|
+|  REL1   |     1     |  up/auf  |    IO1     |       7        | PIO2_2   |                            |
+|  REL2   |     1     | down/zu  |    IO2     |       8        | PIO0_7   |                            |
+|         |           |          |            |                |          |                            |
+|  REL3   |     2     |  up/auf  |    IO3     |       9        | PIO2_10  |                            |
+|  REL4   |     2     | down/zu  |    IO4     |       10       | PIO2_9   |                            |
+|         |           |          |            |                |          |                            |
+|  REL5   |     3     |  up/auf  |    IO5     |       13       | PIO0_2   |                            |
+|  REL6   |     3     | down/zu  |    IO6     |       14       | PIO0_8   |                            |
+|         |           |          |            |                |          |                            |
+|  REL7   |     4     |  up/auf  |    IO7     |       15       | PIO0_9   |                            |
+|  REL8   |     4     | down/zu  |    IO8     |       16       | PIO2_11  |                            |
+|         |           |          |            |                |          |                            |
+|  REL9   |     5     |  up/auf  |  UART-TxD  |       17       | PIO3_0   |                            |
+|  REL10  |     5     | down/zu  |  UART-RxD  |       18       | PIO3_1   |                            |
+|         |           |          |            |                |          |                            |
+|  REL11  |     6     |  up/auf  |    IO9     |       19       | PIO1_0   |                            |
+|  REL12  |     6     | down/zu  |    IO10    |       20       | PIO1_1   |                            |
+|         |           |          |            |                |          |                            |
+|  REL13  |     7     |  up/auf  |    IO12    |       23       | PIO1_2   |                            |
+|  REL14  |     7     | down/zu  |    IO13    |       24       | PIO1_4   |                            |
+|         |           |          |            |                |          |                            |
+|  REL15  |     8     |  up/auf  |    IO14    |       25       | PIO1_7   |                            |
+|  REL16  |     8     | down/zu  |    IO15    |       26       | PIO1_6   |                            |
+|         |           |          |            |                |          |                            |
+|         |           |   PWM    |  PIN_PWM   |       3        | PIO3_2   | pulse wide modulation      |
+|         |           |   VDD    |            |       6        |          | EIB_DC (R1 680R to VDD)    |
+
+## optional hand actuation LedTaster_4TE ([PCB](https://github.com/selfbus/hardware-merged/tree/main/addons/leds_buttons_lpc922ctrl_4MU), [Wiki (legacy)](https://selfbus.myxwiki.org/xwiki/bin/view/Technik/LedTasterBoard_4TE))
+### used IO Ports (verwendete IO Ports):
+|    Function    | Selfbus IO | Selfbus LT | ARM Port | Description (Beschreibung) |
+|:--------------:|:----------:|:----------:|----------|----------------------------|
+| LED 1 / Btn 1  |  PIN_LT1   |     1      | PIO2_1   |                            |
+| LED 2 / Btn 2  |  PIN_LT2   |     2      | PIO0_3   |                            |
+| LED 3 / Btn 3  |  PIN_LT3   |     3      | PIO2_4   |                            |
+| LED 4 / Btn 4  |  PIN_LT4   |     4      | PIO2_5   |                            |
+| LED 5 / Btn 5  |  PIN_LT5   |     5      | PIO3_5   |                            |
+| LED 6 / Btn 6  |  PIN_LT6   |     6      | PIO3_4   |                            |
+| LED 7 / Btn 7  |  PIN_LT7   |     7      | PIO1_10  |                            |
+| LED 8 / Btn 8  |  PIN_LT8   |     8      | PIO0_11  |                            |
+|    Readback    |  PIN_LT9   |     9      | PIO2_3   |                            |
+
+## See [config.h](inc/config.h) for additional information.

--- a/actuators/blind-shutter/rol-jal-bim112/README.md
+++ b/actuators/blind-shutter/rol-jal-bim112/README.md
@@ -40,7 +40,7 @@ Zur ETS-Konfiguration die [MDT_KP_Jalousieaktor_V28.knxprod](https://www.mdt.de/
 |  REL8   | 4         | down/zu  |    IO8     |       16       | PIO2_11  |                            |
 |         |           |          |            |                |          |                            |
 |         |           |   PWM    |  PIN_PWM   |       3        | PIO3_2   | pulse wide modulation      |
-|         |           |   VDD    |            |       6        |          | EIB_DC (R1 680R to VDD)    |
+|         |           |   VDD    |            |       6        |          | EIB_DC                     |
 
 -------------
 
@@ -73,7 +73,7 @@ Zur ETS-Konfiguration die [MDT_KP_Jalousieaktor_V28.knxprod](https://www.mdt.de/
 |  REL16  |     8     | down/zu  |    IO15    |       26       | PIO1_6   |                            |
 |         |           |          |            |                |          |                            |
 |         |           |   PWM    |  PIN_PWM   |       3        | PIO3_2   | pulse wide modulation      |
-|         |           |   VDD    |            |       6        |          | EIB_DC (R1 680R to VDD)    |
+|         |           |   VDD    |            |       6        |          | EIB_DC                     |
 
 ## optional hand actuation LedTaster_4TE ([PCB](https://github.com/selfbus/hardware-merged/tree/main/addons/leds_buttons_lpc922ctrl_4MU), [Wiki (legacy)](https://selfbus.myxwiki.org/xwiki/bin/view/Technik/LedTasterBoard_4TE))
 ### used IO Ports (verwendete IO Ports):

--- a/actuators/blind-shutter/rol-jal-bim112/README.md
+++ b/actuators/blind-shutter/rol-jal-bim112/README.md
@@ -90,3 +90,10 @@ Zur ETS-Konfiguration die [MDT_KP_Jalousieaktor_V28.knxprod](https://www.mdt.de/
 |    Readback    |  PIN_LT9   |     9      | PIO2_3   |                            |
 
 ## See [config.h](inc/config.h) for additional information.
+
+# ToDo for Blind/Shutter
+
+- implement correct handling of upper/lower limit
+- implement bus return/bus down handling
+- check the meaning of LOCK ABS Positioning
+- create 8-fold PCB

--- a/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
@@ -24,7 +24,7 @@
     HandActuation* handAct = new HandActuation(&handPins[0], NO_OF_HAND_PINS, READBACK_PIN, BLINK_TIME);
 #endif
 
-Channel * channels[NO_OF_CHANNELS];
+Channel * channels[CHANNEL_COUNT];
 
 uint8_t channelCount()
 {

--- a/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
@@ -24,7 +24,7 @@
     HandActuation* handAct = new HandActuation(&handPins[0], NO_OF_HAND_PINS, READBACK_PIN, BLINK_TIME);
 #endif
 
-Channel * channels[CHANNEL_COUNT];
+Channel * channels[CHANNEL_COUNT] = {};
 
 uint8_t channelCount()
 {
@@ -185,12 +185,23 @@ void initApplication(short channelPositions[], short channelSlatPositions[])
             slatPosition = 0;
         }
 
+        if (channels[i] != nullptr)
+        {
+            delete channels[i];
+        }
+
         switch (bcu.userEeprom->getUInt8(address))
         {
-        case 0: channels [i] = new Blind(i, address, position, slatPosition); break;
-        case 1: channels [i] = new Shutter(i, address, position); break;
-        default :
-            channels [i] = 0;
+            case 0:
+                channels[i] = new Blind(i, address, position, slatPosition);
+                break;
+
+            case 1:
+                channels[i] = new Shutter(i, address, position);
+                break;
+
+            default :
+                channels[i] = nullptr;
         }
 
         if (channels[i] != nullptr)

--- a/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
@@ -25,12 +25,6 @@
 #endif
 
 Channel * channels[NO_OF_CHANNELS];
-#ifdef MEM_TEST
-Blind b0 = Blind(0, 0);
-Blind b1 = Blind(1, 1);
-Blind b2 = Blind(2, 2);
-Shutter b3 = Shutter(3, 3);
-#endif
 
 uint8_t channelCount()
 {

--- a/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
@@ -161,7 +161,7 @@ void initApplication(short channelPositions[], short channelSlatPositions[])
 {
     Channel::initPWM(PIN_PWM);  // configure digital pin PIO3_2 (PIN_PWM) and timer16_0 for PWM
 
-    unsigned int address = currentVersion->baseAddress;
+    unsigned int address = currentVersion.baseAddress;
 
     for (uint8_t i = 0; i < sizeof(outputPins)/sizeof(outputPins[0]); i++)
     {

--- a/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.cpp
@@ -32,6 +32,11 @@ Blind b2 = Blind(2, 2);
 Shutter b3 = Shutter(3, 3);
 #endif
 
+uint8_t channelCount()
+{
+    return sizeof(channels)/sizeof(channels[0]);
+}
+
 void objectUpdated(int objno)
 {
     if (objno >= 13)
@@ -44,7 +49,7 @@ void objectUpdated(int objno)
     else
     {   // handle global objects
         unsigned char value = bcu.comObjects->objectRead(objno);
-        for (unsigned int i = 0; i < NO_OF_CHANNELS; i++)
+        for (uint8_t i = 0; i < channelCount(); i++)
         {
             Channel * chn = channels [i];
             if (chn && (objno <= 4) && chn->centralEnabled())
@@ -124,7 +129,7 @@ void checkHandActuation(void)
 
 void checkPeriodicFuntions(void)
 {
-    for (unsigned int i = 0; i < NO_OF_CHANNELS; i++)
+    for (uint8_t i = 0; i < channelCount(); i++)
     {
         Channel * chn = channels[i];
         if (chn)
@@ -140,7 +145,7 @@ void checkPeriodicFuntions(void)
 }
 
 void getChannelPositions(short channelPositions[], short channelSlatPositions[]){
-    for (unsigned int i = 0; i < NO_OF_CHANNELS; i++)
+    for (uint8_t i = 0; i < channelCount(); i++)
     {
         if (channels[i] != nullptr)
         {
@@ -158,13 +163,13 @@ void initApplication(short channelPositions[], short channelSlatPositions[])
 
     unsigned int address = currentVersion->baseAddress;
 
-    for (unsigned int i = 0; i < NO_OF_OUTPUTS; i++)
+    for (uint8_t i = 0; i < sizeof(outputPins)/sizeof(outputPins[0]); i++)
     {
         pinMode(outputPins[i], OUTPUT);  // first set pinmode to OUTPUT
         digitalWrite(outputPins[i], Channel::OUTPUT_LOW);  // then set pin to low, otherwise relays for deactivated shutter/blind channels (in ETS) will switch on
     }
 
-    for (unsigned int i = 0; i < NO_OF_CHANNELS; i++, address += EE_CHANNEL_CFG_SIZE)
+    for (uint8_t i = 0; i < channelCount(); i++, address += EE_CHANNEL_CFG_SIZE)
     {
         short position;
         short slatPosition;

--- a/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app-rol-jal.h
@@ -13,8 +13,6 @@
 
 #include "channel.h"
 
-extern Channel * channels[NO_OF_CHANNELS];
-
 /**
  * Called from the main loop whenever a com object has been updated
  * via a group address write

--- a/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
@@ -29,16 +29,6 @@
 
 APP_VERSION("SBrol   ", "1", "11") // Don't forget to also change the build-variable sw_version
 
-// Hardware version. Must match the product_serial_number in the VD's table hw_product
-const HardwareVersion hardwareVersion[] =
-{
-    ///\todo implement missing 1, 2, 8- fold versions
-    {4, 0x4578, { 0, 0, 0, 0, 0x0, 0x29 }} // JAL-0410.01 Shutter Actuator 4-fold, 4TE, 230VAC, 10A
-    // {8, 0x46B8, { 0, 0, 0, 0, 0x0, 0x28 }}  // JAL-0810.01 Shutter Actuator 8-fold, 8TE, 230VAC,10A
-};
-
-const HardwareVersion * currentVersion;
-
 Timeout timeout;
 
 void initSerial()
@@ -118,14 +108,12 @@ bool recallAppData()
  */
 BcuBase* setup()
 {
-    ///\todo read some ID pins to determine which version is attached
 
-    currentVersion = & hardwareVersion[0];
-    bcu.begin(MANUFACTURER, currentVersion->hardwareVersion[5], APPVERSION);  // we are a MDT shutter/blind actuator, version 2.8
+    bcu.begin(MANUFACTURER, currentVersion.hardwareVersion[5], APPVERSION);  // we are a MDT shutter/blind actuator, version 2.8
 #ifdef BUSFAIL
     bcu.setUsrCallback((UsrCallback *)&usrCallback);
 #endif
-    bcu.setHardwareType(currentVersion->hardwareVersion, sizeof(currentVersion->hardwareVersion));
+    bcu.setHardwareType(currentVersion.hardwareVersion, sizeof(currentVersion.hardwareVersion));
 
     pinMode(PIN_INFO, OUTPUT); // Info LED
     pinMode(PIN_RUN,  OUTPUT); // Run LED
@@ -231,7 +219,7 @@ void AppCallback::BusVoltageReturn()
         // load default values
         ResetDefaultApplicationData();
     }
-    bcu.begin(MANUFACTURER, currentVersion->hardwareVersion[5], APPVERSION);
+    bcu.begin(MANUFACTURER, currentVersion.hardwareVersion[5], APPVERSION);
     initApplication(AppData.channelPositions, AppData.channelSlatPositions);
 }
 

--- a/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
@@ -113,7 +113,6 @@ BcuBase* setup()
     pinMode(PIN_RUN,  OUTPUT); // Run LED
 #endif
 
-    bcu.begin(MANUFACTURER, currentVersion.hardwareVersion[5], APPVERSION);  // we are a MDT shutter/blind actuator, version 2.8
 #ifdef BUSFAIL
     bcu.setUsrCallback((UsrCallback *)&usrCallback);
 #endif
@@ -130,6 +129,7 @@ BcuBase* setup()
     initApplication();
 #endif
 
+    bcu.begin(MANUFACTURER, currentVersion.hardwareVersion[5], APPVERSION);  // we are a MDT shutter/blind actuator, version 2.8
     return (&bcu);
 }
 

--- a/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
@@ -25,6 +25,8 @@
     ApplicationData AppData;
     AppCallback callback;
     AppUsrCallback usrCallback;
+    ///\todo delete bcuBeginCalled then issue #110 of the sblib is fixed, see https://github.com/selfbus/software-arm-lib/issues/110
+    bool bcuBeginCalled = false;
 #endif
 
 APP_VERSION("SBrol   ", "1", "11") // Don't forget to also change the build-variable sw_version
@@ -130,6 +132,9 @@ BcuBase* setup()
 #endif
 
     bcu.begin(MANUFACTURER, currentVersion.hardwareVersion[5], APPVERSION);  // we are a MDT shutter/blind actuator, version 2.8
+#ifdef BUSFAIL
+    bcuBeginCalled = true;
+#endif
     return (&bcu);
 }
 
@@ -193,7 +198,10 @@ void AppCallback::BusVoltageFail()
     digitalWrite(PIN_INFO, 1);
     // write application settings to flash
     digitalWrite(PIN_INFO, !saveChannelPositions());
-    stopApplication();
+    if (bcuBeginCalled)
+    {
+        stopApplication();
+    }
 
 #ifdef DEBUG
     digitalWrite(PIN_RUN, 0); // switch RUN-LED off, to save some power

--- a/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
@@ -29,8 +29,6 @@
 
 APP_VERSION("SBrol   ", "1", "11") // Don't forget to also change the build-variable sw_version
 
-Timeout timeout;
-
 void initSerial()
 {
 #ifdef DEBUG_SERIAL
@@ -132,7 +130,6 @@ BcuBase* setup()
     initApplication();
 #endif
 
-    timeout.start(1);
     return (&bcu);
 }
 

--- a/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
@@ -108,23 +108,18 @@ bool recallAppData()
  */
 BcuBase* setup()
 {
+#ifdef DEBUG
+    // Running the controller in a closed housing makes these LEDs useless - they just consume power
+    // additionally at the moment the rol-jal application does not make use of these LEDs.
+    pinMode(PIN_INFO, OUTPUT); // Info LED
+    pinMode(PIN_RUN,  OUTPUT); // Run LED
+#endif
 
     bcu.begin(MANUFACTURER, currentVersion.hardwareVersion[5], APPVERSION);  // we are a MDT shutter/blind actuator, version 2.8
 #ifdef BUSFAIL
     bcu.setUsrCallback((UsrCallback *)&usrCallback);
 #endif
     bcu.setHardwareType(currentVersion.hardwareVersion, sizeof(currentVersion.hardwareVersion));
-
-    pinMode(PIN_INFO, OUTPUT); // Info LED
-    pinMode(PIN_RUN,  OUTPUT); // Run LED
-
-    // Running the controller in a closed housing makes these LEDs useless - they just consume power
-    // additionally at the moment the rol-jal application does not make use of these LEDs
-    // check config file to toggle the use
-#ifndef USE_DEV_LEDS
-    digitalWrite(PIN_INFO, 0);
-    digitalWrite(PIN_RUN, 0);
-#endif
 
     // enable bus voltage monitoring
     startBusVoltageMonitoring();

--- a/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app_main.cpp
@@ -192,7 +192,7 @@ void loop_noapp()
 void ResetDefaultApplicationData()
 {
 #ifdef BUSFAIL
-    for(int i = 0; i < NO_OF_CHANNELS; i++){
+    for(uint8_t i = 0; i < sizeof(AppData.channelPositions)/sizeof(AppData.channelPositions[0]); i++){
         AppData.channelPositions[i] = 0;
         AppData.channelSlatPositions[i] = 0;
     }

--- a/actuators/blind-shutter/rol-jal-bim112/src/app_main.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/app_main.h
@@ -22,8 +22,8 @@
 
 #ifdef BUSFAIL
 typedef struct ApplicationData {
-    short channelPositions[NO_OF_CHANNELS];
-    short channelSlatPositions[NO_OF_CHANNELS];
+    short channelPositions[CHANNEL_COUNT];
+    short channelSlatPositions[CHANNEL_COUNT];
 } ApplicationData;
 
 class AppCallback: public BusVoltageCallback {

--- a/actuators/blind-shutter/rol-jal-bim112/src/blind.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/blind.cpp
@@ -152,7 +152,7 @@ void Blind::_startTracking(void)
 bool Blind::_storeScene(unsigned int i)
 {
     bool result = Channel::_storeScene(i);
-    unsigned int address = currentVersion->baseAddress + EE_CHANNEL_CFG_SIZE * number;
+    unsigned int address = currentVersion.baseAddress + EE_CHANNEL_CFG_SIZE * number;
     sceneSlatPos [i] = slatPosition;
     if ((*(bcu.userEeprom))[address + 24 + i] != slatPosition)
     {

--- a/actuators/blind-shutter/rol-jal-bim112/src/blind.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/blind.cpp
@@ -11,26 +11,26 @@
 #include <sblib/timer.h>
 #include "config.h"
 
-Blind::Blind(unsigned int number, unsigned int address, short position, short slatPosition)
-  : Channel(number, address, position)
+Blind::Blind(uint8_t newNumber, uint32_t newAddress, uint16_t newPosition, uint16_t newSlatPosition)
+  : Channel(newNumber, newAddress, newPosition)
   , slatMoveForTime(0)
-  , slatPosition(slatPosition)
+  , slatPosition(newSlatPosition)
   , slatStartPosition(-1)
   , slatTargetPosition(-1)
   , slatSavedPosition(-1)
 {
-    shortTime = bcu.userEeprom->getUInt16(address +   6);
-    slatTime  = bcu.userEeprom->getUInt16(address +  8);
+    shortTime = bcu.userEeprom->getUInt16(newAddress + 6);
+    slatTime  = bcu.userEeprom->getUInt16(newAddress + 8);
     for (unsigned int i = 0; i < NO_OF_SCENES; i++)
     {
-        sceneSlatPos[i] = bcu.userEeprom->getUInt8(address + 24 + i);
+        sceneSlatPos[i] = bcu.userEeprom->getUInt8(newAddress + 24 + i);
     }
-    slatPosAfterMove = bcu.userEeprom->getUInt8(address + 61);
+    slatPosAfterMove = bcu.userEeprom->getUInt8(newAddress + 61);
     for (unsigned int i = 0; i < NO_OF_AUTOMATIC; i++)
     {
-        automaticSlatPos[i] = bcu.userEeprom->getUInt8(address + 44 + i);
+        automaticSlatPos[i] = bcu.userEeprom->getUInt8(newAddress + 44 + i);
     }
-    oneBitSlatPosition = bcu.userEeprom->getUInt8(address + 68);
+    oneBitSlatPosition = bcu.userEeprom->getUInt8(newAddress + 68);
 
     bcu.comObjects->objectSetValue(firstObjNo + COM_OBJ_SLAT_POSITION, slatPosition);
 }

--- a/actuators/blind-shutter/rol-jal-bim112/src/blind.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/blind.h
@@ -17,7 +17,7 @@ class Blind: public Channel
 {
 public:
     Blind() = delete;
-    Blind(unsigned int nummber, unsigned int address, short position, short slatPosition);
+    Blind(uint8_t newNumber, uint32_t newAddress, uint16_t newPosition, uint16_t newSlatPosition);
     virtual ~Blind() = default;
     virtual unsigned int channelType(void);
     //virtual void periodic(void);

--- a/actuators/blind-shutter/rol-jal-bim112/src/blind.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/blind.h
@@ -53,10 +53,10 @@ protected:
     unsigned char  sceneSlatPos[NO_OF_SCENES];    //!< the slat positions for the scenes
 
     // track position of slats
-             short slatPosition;         //!< current channel position
-             short slatStartPosition;    //!< position when the movement started
-             short slatTargetPosition;   //!< requested target position
-             short slatSavedPosition;    //!< position before an automatic commands was triggered
+    short slatPosition;         //!< current channel position
+    short slatStartPosition;    //!< position when the movement started
+    short slatTargetPosition;   //!< requested target position
+    short slatSavedPosition;    //!< position before an automatic commands was triggered
 };
 
 inline unsigned int Blind::channelType(void)

--- a/actuators/blind-shutter/rol-jal-bim112/src/blind.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/blind.h
@@ -18,6 +18,7 @@ class Blind: public Channel
 public:
     Blind() = delete;
     Blind(unsigned int nummber, unsigned int address, short position, short slatPosition);
+    virtual ~Blind() = default;
     virtual unsigned int channelType(void);
     //virtual void periodic(void);
     virtual void moveTo(short position);

--- a/actuators/blind-shutter/rol-jal-bim112/src/channel.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/channel.cpp
@@ -14,10 +14,6 @@
 #include <blind.h> ///\todo Blind is a child class of Channel, something is here wrong
 
 MASK0701 bcu = MASK0701();
-
-const int outputPins[NO_OF_OUTPUTS] =
-    { PIN_IO1, PIN_IO2, PIN_IO3, PIN_IO4, PIN_IO5, PIN_IO6, PIN_IO7, PIN_IO8 };
-
 Timeout PWMDisabled;
 
 
@@ -131,8 +127,8 @@ Channel::Channel(unsigned int number, unsigned int address, short position)
         closeTimeExt   = 1;
     }
     unsigned int baseAddr =
-          currentVersion->baseAddress
-        + currentVersion->noOfChannels * EE_CHANNEL_CFG_SIZE
+          currentVersion.baseAddress
+        + currentVersion.noOfChannels * EE_CHANNEL_CFG_SIZE
         + (EE_ALARM_HEADER_SIZE + EE_ALARM_CFG_SIZE * NO_OF_ALARMS) * number;
 
     reactionLockRemove = bcu.userEeprom->getUInt8  (baseAddr +  8);
@@ -146,8 +142,8 @@ Channel::Channel(unsigned int number, unsigned int address, short position)
         if (bcu.userEeprom->getUInt8 (baseAddr + 4) == 255)
             alarms[i].priority  = 0;
     }
-    baseAddr = currentVersion->baseAddress
-             + currentVersion->noOfChannels
+    baseAddr = currentVersion.baseAddress
+             + currentVersion.noOfChannels
              * (EE_CHANNEL_CFG_SIZE + EE_ALARM_HEADER_SIZE + EE_ALARM_CFG_SIZE * NO_OF_ALARMS);
     busDownAction   = bcu.userEeprom->getUInt8 (baseAddr + 0x00 + 2 * number);
     busReturnAction = bcu.userEeprom->getUInt8 (baseAddr + 0x01 + 2 * number);
@@ -699,7 +695,7 @@ void Channel::_startTracking(void)
 
 bool Channel::_storeScene(unsigned int i)
 {
-    unsigned int address = currentVersion->baseAddress + EE_CHANNEL_CFG_SIZE * number;
+    unsigned int address = currentVersion.baseAddress + EE_CHANNEL_CFG_SIZE * number;
     scenePos [i] = position;
     if ((*(bcu.userEeprom))[address + 32 + i] != position)
     {

--- a/actuators/blind-shutter/rol-jal-bim112/src/channel.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/channel.cpp
@@ -54,9 +54,9 @@ void Channel::setPWMtoMaxDuty()
     TIMER_PWM.match(MAT2, PWM_DUTY_MAX);  // match MAT2 when the timer reaches this value
 }
 
-Channel::Channel(unsigned int number, unsigned int address, short position)
+Channel::Channel(uint8_t newNumber, uint32_t newAddress, uint16_t newPosition)
   : shortTime(0)
-  , number(number)
+  , number(newNumber)
   , firstObjNo(13 + number * 20)
   , positionValid(false)
   , features(0)
@@ -67,54 +67,54 @@ Channel::Channel(unsigned int number, unsigned int address, short position)
   , direction(STOP)
   , moveForTime(0)
   , startTime(0)
-  , position(position)
+  , position(newPosition)
   , startPosition(-1)
   , targetPosition(-1)
   , savedPosition(-1)
   , handAct_(nullptr)
 {
-    for (unsigned int i = number * 2 ;i <= (number * 2 + 1); i++)
+    for (uint8_t i = number * 2; i <= (number * 2 + 1); i++)
     {
         pinMode(outputPins [i], OUTPUT);
         switchOutputPin(outputPins [i], OUTPUT_LOW);
     }
 
-    pauseChangeDir = bcu.userEeprom->getUInt16 (address +   2);
-    openTime       = bcu.userEeprom->getUInt16 (address +   4) * 1000;
-    minMoveTime    = bcu.userEeprom->getUInt8  (address +  10);
+    pauseChangeDir = bcu.userEeprom->getUInt16 (newAddress +   2);
+    openTime       = bcu.userEeprom->getUInt16 (newAddress +   4) * 1000;
+    minMoveTime    = bcu.userEeprom->getUInt8  (newAddress +  10);
     for (unsigned int i = 0; i < NO_OF_SCENES; i++)
     {
-        scenePos[i]    = bcu.userEeprom->getUInt8(address + 16 + i);
-        sceneNumber[i] = bcu.userEeprom->getUInt8(address + 32 + i);
+        scenePos[i]    = bcu.userEeprom->getUInt8(newAddress + 16 + i);
+        sceneNumber[i] = bcu.userEeprom->getUInt8(newAddress + 32 + i);
     }
     for (unsigned int i = 0; i < NO_OF_AUTOMATIC; i++)
     {
-        automaticPos[i] = bcu.userEeprom->getUInt8(address + 40 + i);
+        automaticPos[i] = bcu.userEeprom->getUInt8(newAddress + 40 + i);
     }
-    _enableFeature(address + 48,                FEATURE_STORE_SCENE);
-    //_enableFeature(address + 49,                FEATURE_AUTOMATIK);
-    //_enableFeature(address + 50,                FEATURE_MANUELL);
-    //_enableFeature(address + 51,                FEATURE_ABS_POSITION, 0x04);
-    lockConfig     = bcu.userEeprom->getUInt8  (address +  52);
-    topLimitPos    = bcu.userEeprom->getUInt8  (address +  53);
-    botLimitPos    = bcu.userEeprom->getUInt8  (address +  54);
-    motorOnDelay   = bcu.userEeprom->getUInt8  (address +  55);
-    motorOffDelay  = bcu.userEeprom->getUInt8  (address +  56);
-    // userEeprom.getUInt8  (address +  57); // ?? stop Mode
-    unsigned char extMoveTime    = bcu.userEeprom->getUInt8 (address +  58);
-    _enableFeature(address +  59, FEATURE_RESTORE_AFTER_REF);
-    closeTime      = bcu.userEeprom->getUInt16 (address +  62) * 1000;
+    _enableFeature(newAddress + 48,                FEATURE_STORE_SCENE);
+    //_enableFeature(newAddress + 49,                FEATURE_AUTOMATIK);
+    //_enableFeature(newAddress + 50,                FEATURE_MANUELL);
+    //_enableFeature(newAddress + 51,                FEATURE_ABS_POSITION, 0x04);
+    lockConfig     = bcu.userEeprom->getUInt8  (newAddress +  52);
+    topLimitPos    = bcu.userEeprom->getUInt8  (newAddress +  53);
+    botLimitPos    = bcu.userEeprom->getUInt8  (newAddress +  54);
+    motorOnDelay   = bcu.userEeprom->getUInt8  (newAddress +  55);
+    motorOffDelay  = bcu.userEeprom->getUInt8  (newAddress +  56);
+    // userEeprom.getUInt8  (newAddress +  57); // ?? stop Mode
+    unsigned char extMoveTime    = bcu.userEeprom->getUInt8 (newAddress +  58);
+    _enableFeature(newAddress +  59, FEATURE_RESTORE_AFTER_REF);
+    closeTime      = bcu.userEeprom->getUInt16 (newAddress +  62) * 1000;
     if (closeTime == 0)
         closeTime = openTime;
-    unsigned char lockAbsPos     = bcu.userEeprom->getUInt8  (address +  64);
+    unsigned char lockAbsPos     = bcu.userEeprom->getUInt8  (newAddress +  64);
     if (lockAbsPos & 0x80)
         lockConfig |= LOCK_POS_UP_DOWN;
     if (lockAbsPos & 0x20)
         lockConfig |= LOCK_POS_RELEASE_UP;
-    _enableFeature(address + 65,                FEATURE_STATUS_MOVING,   0x80);
-    _enableFeature(address + 65,                FEATURE_SHORT_OPERATION, 0x40);
-    obj24Config    = bcu.userEeprom->getUInt8(address + 66);
-    oneBitPosition = bcu.userEeprom->getUInt8(address + 67);
+    _enableFeature(newAddress + 65,                FEATURE_STATUS_MOVING,   0x80);
+    _enableFeature(newAddress + 65,                FEATURE_SHORT_OPERATION, 0x40);
+    obj24Config    = bcu.userEeprom->getUInt8(newAddress + 66);
+    oneBitPosition = bcu.userEeprom->getUInt8(newAddress + 67);
 
     if (extMoveTime != 0)
     {

--- a/actuators/blind-shutter/rol-jal-bim112/src/channel.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/channel.h
@@ -148,6 +148,7 @@ public:
     static void setPWMtoMaxDuty();
     Channel() = delete;
     Channel(unsigned int number, unsigned int address, short position);
+    virtual ~Channel() = default;
     virtual unsigned int channelType(void);
 
     unsigned int isRunning(void);

--- a/actuators/blind-shutter/rol-jal-bim112/src/channel.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/channel.h
@@ -147,7 +147,7 @@ public:
     static void startPWM();
     static void setPWMtoMaxDuty();
     Channel() = delete;
-    Channel(unsigned int number, unsigned int address, short position);
+    Channel(uint8_t newNumber, uint32_t newAddress, uint16_t newPosition);
     virtual ~Channel() = default;
     virtual unsigned int channelType(void);
 

--- a/actuators/blind-shutter/rol-jal-bim112/src/channel.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/channel.h
@@ -13,16 +13,14 @@
 #include <sblib/timeout.h>
 #include <sblib/timer.h>
 #include <sblib/eibMASK0701.h>
+#include "config.h"
 #include "hand_actuation.h"
 
-#define NO_OF_CHANNELS 4
-#define NO_OF_OUTPUTS  (NO_OF_CHANNELS * 2)
 #define NO_OF_AUTOMATIC 4
 #define NO_OF_SCENES    8
 #define NO_OF_ALARMS    4
 
 extern MASK0701 bcu;
-extern const int outputPins[NO_OF_OUTPUTS];
 extern Timeout PWMDisabled;
 
 /* old PWM values from rol-jal-bim112

--- a/actuators/blind-shutter/rol-jal-bim112/src/config.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/config.h
@@ -17,6 +17,8 @@
 #define APPVERSION   0x28
 
 //#define HAND_ACTUATION
+#define NO_OF_CHANNELS 4
+
 //#define USE_DEV_LEDS
 //#define MEM_TEST
 
@@ -27,9 +29,24 @@ typedef struct
     byte hardwareVersion[6];    //!> The hardware identification number. Must match the product_serial_number in the VD's table hw_product
 } HardwareVersion;
 
-extern const HardwareVersion * currentVersion;
 
-
+#define NO_OF_OUTPUTS  (NO_OF_CHANNELS * 2)
+#if NO_OF_CHANNELS == 4
+    // JAL-0410.01 Shutter Actuator 4-fold, 4TE, 230VAC, 10A
+    const HardwareVersion currentVersion = {4, 0x4578, { 0, 0, 0, 0, 0x0, 0x29 }};
+    const int outputPins[NO_OF_OUTPUTS] =
+        { PIN_IO1, PIN_IO2, PIN_IO3, PIN_IO4, PIN_IO5, PIN_IO6, PIN_IO7, PIN_IO8 };
+#elif NO_OF_CHANNELS == 8
+    // JAL-0810.01 Shutter Actuator 8-fold, 8TE, 230VAC,10A
+    const HardwareVersion currentVersion = {8, 0x46B8, { 0, 0, 0, 0, 0x0, 0x28 }};
+    const int outputPins[NO_OF_OUTPUTS] =
+        {
+          PIN_IO1, PIN_IO2, PIN_IO3, PIN_IO4, PIN_IO5, PIN_IO6, PIN_IO7, PIN_IO8,
+          PIN_TX, PIN_RX, PIN_IO9, PIN_IO10, PIN_IO12, PIN_IO13, PIN_IO14, PIN_IO15
+        };
+#else
+#   error "NO_OF_CHANNELS must be defined"
+#endif
 
 /*
  *  bus power-failure configuration
@@ -52,6 +69,9 @@ extern const HardwareVersion * currentVersion;
  *  hand actuation pin configuration
  */
 #ifdef HAND_ACTUATION
+#   if NO_OF_CHANNELS != 4
+#       error "HAND_ACTUATION only supported for NO_OF_CHANNELS == 4"
+#   endif
 #   define NO_OF_HAND_PINS 8
 #   define READBACK_PIN PIN_LT9
 #   define BLINK_TIME 500

--- a/actuators/blind-shutter/rol-jal-bim112/src/config.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/config.h
@@ -19,7 +19,6 @@
 //#define HAND_ACTUATION
 #define NO_OF_CHANNELS 4
 
-//#define USE_DEV_LEDS
 //#define MEM_TEST
 
 typedef struct

--- a/actuators/blind-shutter/rol-jal-bim112/src/config.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/config.h
@@ -16,7 +16,15 @@
 #define MANUFACTURER 131
 #define APPVERSION   0x28
 
-//#define HAND_ACTUATION
+/**
+ * @def HAND_ACTUATION
+ * Define to compile with hand actuation support.
+ *
+ * @note Currently set by build variable ${hand_actuation} in eclipse menu "Project properties->C/C++ Build->Build Variables"
+ * @warning Hand actuation is currently only supported for 4-channel builds.
+ */
+// #define HAND_ACTUATION
+
 #define NO_OF_CHANNELS 4
 
 //#define MEM_TEST
@@ -29,7 +37,8 @@ typedef struct
 } HardwareVersion;
 
 
-#define NO_OF_OUTPUTS  (NO_OF_CHANNELS * 2)
+#define NO_OF_OUTPUTS (NO_OF_CHANNELS * 2)
+
 #if NO_OF_CHANNELS == 4
     // JAL-0410.01 Shutter Actuator 4-fold, 4TE, 230VAC, 10A
     const HardwareVersion currentVersion = {4, 0x4578, { 0, 0, 0, 0, 0x0, 0x29 }};

--- a/actuators/blind-shutter/rol-jal-bim112/src/config.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/config.h
@@ -36,6 +36,7 @@ typedef struct
     const int outputPins[NO_OF_OUTPUTS] =
         { PIN_IO1, PIN_IO2, PIN_IO3, PIN_IO4, PIN_IO5, PIN_IO6, PIN_IO7, PIN_IO8 };
 #elif NO_OF_CHANNELS == 8
+#   warning "8 channel build is experimental!"
     // JAL-0810.01 Shutter Actuator 8-fold, 8TE, 230VAC,10A
     const HardwareVersion currentVersion = {8, 0x46B8, { 0, 0, 0, 0, 0x0, 0x28 }};
     const int outputPins[NO_OF_OUTPUTS] =

--- a/actuators/blind-shutter/rol-jal-bim112/src/config.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/config.h
@@ -16,20 +16,20 @@
 #define MANUFACTURER 131
 #define APPVERSION   0x28
 
+//#define HAND_ACTUATION
+//#define USE_DEV_LEDS
+//#define MEM_TEST
+
 typedef struct
 {
     unsigned int noOfChannels;  //!> how many channels are supported with this hardware
     unsigned short baseAddress; //!> Base address of the config parameters
-    byte hardwareVersion[6];    //!> The hardware identification number
+    byte hardwareVersion[6];    //!> The hardware identification number. Must match the product_serial_number in the VD's table hw_product
 } HardwareVersion;
 
 extern const HardwareVersion * currentVersion;
 
 
-//#define HAND_ACTUATION
-
-//#define USE_DEV_LEDS
-//#define MEM_TEST
 
 /*
  *  bus power-failure configuration

--- a/actuators/blind-shutter/rol-jal-bim112/src/config.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/config.h
@@ -25,7 +25,13 @@
  */
 // #define HAND_ACTUATION
 
-#define NO_OF_CHANNELS 4
+/**
+ * @def CHANNEL_COUNT
+ * Define to set the number of blind/fold channels (1, 2, 4 or 8)
+ *
+ * @warning Currently only 4 or 8 channels are supported (8 Channels experimental).
+ */
+#define CHANNEL_COUNT 4
 
 typedef struct
 {
@@ -35,14 +41,14 @@ typedef struct
 } HardwareVersion;
 
 
-#define NO_OF_OUTPUTS (NO_OF_CHANNELS * 2)
+#define NO_OF_OUTPUTS (CHANNEL_COUNT * 2)
 
-#if NO_OF_CHANNELS == 4
+#if CHANNEL_COUNT == 4
     // JAL-0410.01 Shutter Actuator 4-fold, 4TE, 230VAC, 10A
     const HardwareVersion currentVersion = {4, 0x4578, { 0, 0, 0, 0, 0x0, 0x29 }};
     const int outputPins[NO_OF_OUTPUTS] =
         { PIN_IO1, PIN_IO2, PIN_IO3, PIN_IO4, PIN_IO5, PIN_IO6, PIN_IO7, PIN_IO8 };
-#elif NO_OF_CHANNELS == 8
+#elif CHANNEL_COUNT == 8
 #   warning "8 channel build is experimental!"
     // JAL-0810.01 Shutter Actuator 8-fold, 8TE, 230VAC,10A
     const HardwareVersion currentVersion = {8, 0x46B8, { 0, 0, 0, 0, 0x0, 0x28 }};
@@ -52,7 +58,7 @@ typedef struct
           PIN_TX, PIN_RX, PIN_IO9, PIN_IO10, PIN_IO12, PIN_IO13, PIN_IO14, PIN_IO15
         };
 #else
-#   error "NO_OF_CHANNELS must be defined"
+#   error "CHANNEL_COUNT must be defined"
 #endif
 
 /*
@@ -76,8 +82,8 @@ typedef struct
  *  hand actuation pin configuration
  */
 #ifdef HAND_ACTUATION
-#   if NO_OF_CHANNELS != 4
-#       error "HAND_ACTUATION only supported for NO_OF_CHANNELS == 4"
+#   if CHANNEL_COUNT != 4
+#       error "HAND_ACTUATION only supported for CHANNEL_COUNT == 4"
 #   endif
 #   define NO_OF_HAND_PINS 8
 #   define READBACK_PIN PIN_LT9

--- a/actuators/blind-shutter/rol-jal-bim112/src/config.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/config.h
@@ -29,9 +29,10 @@
  * @def CHANNEL_COUNT
  * Define to set the number of blind/fold channels (1, 2, 4 or 8)
  *
+ * @note Set by build variable ${channel_count} in eclipse menu "Project properties->C/C++ Build->Build Variables"
  * @warning Currently only 4 or 8 channels are supported (8 Channels experimental).
  */
-#define CHANNEL_COUNT 4
+// #define CHANNEL_COUNT 4
 
 typedef struct
 {

--- a/actuators/blind-shutter/rol-jal-bim112/src/config.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/config.h
@@ -27,8 +27,6 @@
 
 #define NO_OF_CHANNELS 4
 
-//#define MEM_TEST
-
 typedef struct
 {
     unsigned int noOfChannels;  //!> how many channels are supported with this hardware

--- a/actuators/blind-shutter/rol-jal-bim112/src/shutter.cpp
+++ b/actuators/blind-shutter/rol-jal-bim112/src/shutter.cpp
@@ -8,11 +8,9 @@
 
 #include <shutter.h>
 
-Shutter::Shutter(unsigned int number, unsigned int address, short position)
-  : Channel(number, address, position)
+Shutter::Shutter(uint8_t newNumber, uint32_t newAddress, uint16_t newPosition)
+  : Channel(newNumber, newAddress, newPosition)
 {
-    if (bcu.userEeprom->getUInt8(address +   65) & 0x40)
-        shortTime = bcu.userEeprom->getUInt16(address +   6);
+    if (bcu.userEeprom->getUInt8(newAddress + 65) & 0x40)
+        shortTime = bcu.userEeprom->getUInt16(newAddress + 6);
 }
-
-

--- a/actuators/blind-shutter/rol-jal-bim112/src/shutter.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/shutter.h
@@ -18,6 +18,7 @@ class Shutter: public Channel
 public:
     Shutter() = delete;
     Shutter(unsigned int number, unsigned int address, short position);
+    virtual ~Shutter() = default;
 };
 
 #endif /* ROL_JAL_BIM112_SRC_SHUTTER_H_ */

--- a/actuators/blind-shutter/rol-jal-bim112/src/shutter.h
+++ b/actuators/blind-shutter/rol-jal-bim112/src/shutter.h
@@ -17,7 +17,7 @@ class Shutter: public Channel
 {
 public:
     Shutter() = delete;
-    Shutter(unsigned int number, unsigned int address, short position);
+    Shutter(uint8_t newNumber, uint32_t newAddress, uint16_t newPosition);
     virtual ~Shutter() = default;
 };
 

--- a/actuators/blind-shutter/rol-jal-bim112/src/todo.txt
+++ b/actuators/blind-shutter/rol-jal-bim112/src/todo.txt
@@ -1,6 +1,0 @@
-ToDo for Blind/Shutter
-======================
-
-- implement correct handling of upper/lower limit
-- implement bus return/bus down handling
-- check the meaning of LOCK ABS Positioning


### PR DESCRIPTION
This PR adds 8-channel support to the *rol-jal-bim112* along with code refactoring, bug fixes and improved documentation.

### 8-Channel Support
- Added 8-channel build (experimental)

### Bug Fixes
- Fixed memory leak, prevent multiple instances of `Blind` or `Shutter`  on KNX bus voltage drops e6b647a
- Fixed infinite loop issue if `stopApplication` was called before `bcu.begin()` (workaround for [sblib issue #110](https://github.com/selfbus/software-arm-lib/issues/110))

### Documentation
- Added README.md with pin mappings and configuration details

## Breaking Changes
- Build configuration names now include channel count suffix (e.g., `_4ch`)
- `NO_OF_CHANNELS` renamed to `CHANNEL_COUNT`

## Todo
- design 8-channel PCB