### PR TITLE
[RTR] Fix device-type and app-version mismatch

### DIFF
--- a/sensors/misc/RTR_lcd_voc_rh_sensor-bcu1/inc/knxprodHeader.h
+++ b/sensors/misc/RTR_lcd_voc_rh_sensor-bcu1/inc/knxprodHeader.h
@@ -26,8 +26,8 @@
 
 
 #define MANUFACTURER 76 //!< Manufacturer ID
-#define DEVICETYPE 16 //!< Device Type
-#define APPVERSION 32 //!< Application Version
+#define DEVICETYPE 0x47e //!< Device Type
+#define APPVERSION 18 //!< Application Version 1.2
 
 
 


### PR DESCRIPTION
This PR fixes device-type and app-version mismatch, which causes ETS *Compare Device* to fail.

<img width="543" height="102" alt="rtr_ets_compare" src="https://github.com/user-attachments/assets/5a1a58e7-0dd2-4fbc-b037-9e7b75addd3b" />

failed *ETS Compare Device*