### PR TITLE
[RM] Fix Test 8.3.e description typo

### DIFF
--- a/misc/Rauchmelder-bcu1/doc/tests/tests_B_3.md
+++ b/misc/Rauchmelder-bcu1/doc/tests/tests_B_3.md
@@ -110,7 +110,7 @@ Setup per finished [Tests B.1](tests_B_1.md), i.e. fully configured module mount
 ## B.3.e
 
 **Steps:**
-* In ETS, set parameters on Status Informations page as follows (same as B.3.d, but with periodic sending turned off)
+* In ETS, set parameters on Status Informations page as follows (same as B.3.d, periodic sending turned on)
   - Send status informations periodically: Yes
   - Interval [min]: 1
   - Serial number: **Yes**


### PR DESCRIPTION
We expect the serial number to be sent every minute. Without periodic sending, this will never happen.